### PR TITLE
feat: add can withdraw fees to fee manager

### DIFF
--- a/src/fee-manager/FeeManager.sol
+++ b/src/fee-manager/FeeManager.sol
@@ -16,6 +16,9 @@ contract FeeManager is IFeeManager, AccessControlDefaultAdminRules {
   bytes32 public constant MANAGE_FEES_ROLE = keccak256("MANAGE_FEES_ROLE");
 
   /// @inheritdoc IFeeManager
+  bytes32 public constant WITHDRAW_FEES_ROLE = keccak256("WITHDRAW_FEES_ROLE");
+
+  /// @inheritdoc IFeeManager
   uint16 public constant MAX_FEE = 5000; // 50%
 
   mapping(StrategyId strategy => StrategyFees fees) internal _fees;
@@ -24,11 +27,13 @@ contract FeeManager is IFeeManager, AccessControlDefaultAdminRules {
   constructor(
     address superAdmin,
     address[] memory initialManageFeeAdmins,
+    address[] memory initialWithdrawFeeAdmins,
     Fees memory initialDefaultFees
   )
     AccessControlDefaultAdminRules(3 days, superAdmin)
   {
     _assignRoles(MANAGE_FEES_ROLE, initialManageFeeAdmins);
+    _assignRoles(WITHDRAW_FEES_ROLE, initialWithdrawFeeAdmins);
     _setDefaultFees(initialDefaultFees);
   }
 
@@ -66,6 +71,11 @@ contract FeeManager is IFeeManager, AccessControlDefaultAdminRules {
   /// @inheritdoc IFeeManager
   function setDefaultFees(Fees memory newFees) external override onlyRole(MANAGE_FEES_ROLE) {
     _setDefaultFees(newFees);
+  }
+
+  /// @inheritdoc IFeeManager
+  function canWithdrawFees(StrategyId, address caller) external view returns (bool) {
+    return hasRole(WITHDRAW_FEES_ROLE, caller);
   }
 
   function _setDefaultFees(Fees memory newFees) internal {

--- a/src/interfaces/IFeeManager.sol
+++ b/src/interfaces/IFeeManager.sol
@@ -33,6 +33,13 @@ interface IFeeManager {
   function MANAGE_FEES_ROLE() external view returns (bytes32);
 
   /**
+   * @notice Returns the role in charge of withdrawing fees
+   * @return The role in charge of withdrawing fees
+   */
+  // slither-disable-next-line naming-convention
+  function WITHDRAW_FEES_ROLE() external view returns (bytes32);
+
+  /**
    * @notice Returns the max amount of fee possible
    * @return The max amount of fee possible
    */
@@ -45,6 +52,9 @@ interface IFeeManager {
    * @return The strategy fees
    */
   function getFees(StrategyId strategyId) external view returns (Fees memory);
+
+  /// @notice Returns if the caller can withdraw fees from the strategy
+  function canWithdrawFees(StrategyId strategyId, address caller) external view returns (bool);
 
   /**
    * @notice Updates the fees for a strategy


### PR DESCRIPTION
We are now adding `canWithdrawFees` to the fee manager, so our Fee layer on the strategy can verify (in another PR) if callers can withdraw fees or not