### PR TITLE
refactor: external guardian - handle fee config on strategy

### DIFF
--- a/src/interfaces/IGuardianManager.sol
+++ b/src/interfaces/IGuardianManager.sol
@@ -22,18 +22,18 @@ interface IGuardianManagerCore {
   function strategySelfConfigure(bytes calldata data) external;
 
   /**
-   * @notice Starts a rescue
+   * @notice Alerts that a rescue has started
    * @dev Will revert if the rescue is already in progress or if it has been confirmed already
    */
-  function startRescue(StrategyId strategyId, address feeRecipient) external;
+  function rescueStarted(StrategyId strategyId) external;
   /**
-   * @notice Cancels a rescue
+   * @notice Alerts that a rescue has been cancelled
    * @dev Will revert if the rescue is not in progress
    */
-  function cancelRescue(StrategyId strategyId) external;
+  function rescueCancelled(StrategyId strategyId) external;
   /**
-   * @notice Confirms a rescue
+   * @notice Alerts that a rescue has been confirmed
    * @dev Will revert if the rescue is not in progress
    */
-  function confirmRescue(StrategyId strategyId) external returns (address feeRecipient, uint16 rescueFeeBps);
+  function rescueConfirmed(StrategyId strategyId) external;
 }


### PR DESCRIPTION
We are now making two changes:
- The GuardianManager will only be "alerted" when an action is executed
- The strategy will be the one that holds information about the fee recipient and fee bps. We do this so that the guardian manager doesn't need to know the fee manager, and we are not occupying more storage slot