### PR TITLE
feat: guardian manager - add and remove judges

### DIFF
--- a/src/interfaces/IGuardianManager.sol
+++ b/src/interfaces/IGuardianManager.sol
@@ -41,6 +41,8 @@ interface IGuardianManagerCore {
 interface IGuardianManager is IGuardianManagerCore {
   event GuardiansAssigned(StrategyId strategyId, address[] accounts);
   event GuardiansRemoved(StrategyId strategyId, address[] accounts);
+  event JudgesAssigned(StrategyId strategyId, address[] accounts);
+  event JudgesRemoved(StrategyId strategyId, address[] accounts);
 
   /**
    * @notice Returns the address of the strategy registry


### PR DESCRIPTION
We are now implementing `isJudge`, `assignJudges` and `removeJudges`