### PR TITLE
feat: guardian manager - can X rescue

### DIFF
--- a/src/guardian-manager/GuardianManager.sol
+++ b/src/guardian-manager/GuardianManager.sol
@@ -62,13 +62,19 @@ contract GuardianManager is IGuardianManager, AccessControlDefaultAdminRules {
   }
 
   /// @inheritdoc IGuardianManagerCore
-  function canStartRescue(StrategyId strategyId, address account) external view returns (bool) { }
+  function canStartRescue(StrategyId strategyId, address account) external view returns (bool) {
+    return isGuardian(strategyId, account) || hasRole(GLOBAL_GUARDIAN_ROLE, account);
+  }
   /// @inheritdoc IGuardianManagerCore
 
-  function canCancelRescue(StrategyId strategyId, address account) external view returns (bool) { }
+  function canCancelRescue(StrategyId strategyId, address account) external view returns (bool) {
+    return isGuardian(strategyId, account) || hasRole(GLOBAL_GUARDIAN_ROLE, account);
+  }
   /// @inheritdoc IGuardianManagerCore
 
-  function canConfirmRescue(StrategyId strategyId, address account) external view returns (bool) { }
+  function canConfirmRescue(StrategyId strategyId, address account) external view returns (bool) {
+    return isJudge(strategyId, account) || hasRole(GLOBAL_JUDGE_ROLE, account);
+  }
 
   /// @inheritdoc IGuardianManagerCore
   function strategySelfConfigure(bytes calldata data) external {

--- a/test/unit/guardian-manager/GuardianManager.t.sol
+++ b/test/unit/guardian-manager/GuardianManager.t.sol
@@ -58,6 +58,60 @@ contract GuardianManagerTest is PRBTest {
     assertEq(manager.defaultAdmin(), superAdmin);
   }
 
+  function test_canStartRescue_strategyGuardian() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    address guardian = address(30);
+    vm.prank(manageGuardiansAdmin);
+    manager.assignGuardians(strategyId, CommonUtils.arrayOf(guardian));
+    assertTrue(manager.canStartRescue(strategyId, guardian));
+  }
+
+  function test_canStartRescue_globalGuardian() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    assertTrue(manager.canStartRescue(strategyId, globalGuardian));
+  }
+
+  function test_canStartRescue_notGuardian() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    assertFalse(manager.canStartRescue(strategyId, address(30)));
+  }
+
+  function test_canCancelRescue_strategyGuardian() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    address guardian = address(30);
+    vm.prank(manageGuardiansAdmin);
+    manager.assignGuardians(strategyId, CommonUtils.arrayOf(guardian));
+    assertTrue(manager.canCancelRescue(strategyId, guardian));
+  }
+
+  function test_canCancelRescue_globalGuardian() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    assertTrue(manager.canCancelRescue(strategyId, globalGuardian));
+  }
+
+  function test_canCancelRescue_notGuardian() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    assertFalse(manager.canCancelRescue(strategyId, address(30)));
+  }
+
+  function test_canConfirmRescue_strategyJudge() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    address judge = address(30);
+    vm.prank(manageJudgesAdmin);
+    manager.assignJudges(strategyId, CommonUtils.arrayOf(judge));
+    assertTrue(manager.canConfirmRescue(strategyId, judge));
+  }
+
+  function test_canConfirmRescue_globalJudge() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    assertTrue(manager.canConfirmRescue(strategyId, globalJudge));
+  }
+
+  function test_canConfirmRescue_notJusge() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    assertFalse(manager.canConfirmRescue(strategyId, address(30)));
+  }
+
   function test_strategySelfConfigure_emptyBytes() public {
     // Nothing happens
     manager.strategySelfConfigure("");


### PR DESCRIPTION
We are now implementing `canStartRescue`, `canCancelRescue` and `canConfirmRescue`