### PR TITLE
    feat: add selfconfigure to interface and layer test

### DIFF
--- a/src/interfaces/ILiquidityMiningManager.sol
+++ b/src/interfaces/ILiquidityMiningManager.sol
@@ -47,6 +47,9 @@ interface ILiquidityMiningManagerCore {
    * @param assetsWithdrawn The amount of assets withdrew
    */
   function withdrew(StrategyId strategyId, uint256 assetsWithdrawn) external;
+
+  /// @notice Allows the strategy to call the manager, for self-configuration
+  function strategySelfConfigure(bytes calldata data) external;
 }
 
 /**

--- a/src/strategies/layers/liquidity-mining/ExternalLiquidityMining.sol
+++ b/src/strategies/layers/liquidity-mining/ExternalLiquidityMining.sol
@@ -20,11 +20,10 @@ abstract contract ExternalLiquidityMining is BaseLiquidityMining, Initializable 
   /// @notice The id assigned to this strategy
   function strategyId() public view virtual returns (StrategyId);
 
-  // solhint-disable no-empty-blocks
   // slither-disable-next-line naming-convention,dead-code
   function _liquidity_mining_init(bytes calldata data) internal onlyInitializing {
-    // TODO: implement
-    // manager.strategySelfConfigure(data);
+    ILiquidityMiningManagerCore manager = _getLiquidityMiningManager();
+    manager.strategySelfConfigure(data);
   }
 
   // slither-disable-start assembly

--- a/test/unit/strategies/layers/liquidity-mining/ExternalLiquidityMining.t.sol
+++ b/test/unit/strategies/layers/liquidity-mining/ExternalLiquidityMining.t.sol
@@ -32,14 +32,18 @@ contract ExternalLiquidityMiningTest is Test {
       abi.encodeWithSelector(ILiquidityMiningManagerCore.rewards.selector, strategyId),
       abi.encode(CommonUtils.arrayOf(lmReward, lmRewardRepeated))
     );
+
+    vm.mockCall(
+      address(manager), abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector), ""
+    );
   }
 
   function test_init() public {
     bytes memory data = "1234567";
+    vm.expectCall(
+      address(manager), abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, data)
+    );
     liquidityMining.init(data);
-    // TODO: test self configure
-    //vm.expectCall(address(manager), abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector,
-    // data));
   }
 
   function test_allTokens() public {


### PR DESCRIPTION
This pull request adds the `strategySelfConfigure` function to the `ILiquidityMiningManagerCore` interface and includes a test for it in the `ExternalLiquidityMiningTest` contract. The `strategySelfConfigure` function allows the strategy to call the manager for self-configuration.