### PR TITLE
Add IERC165 interface support to BaseDelayedStrategy and BaseStrategy

### DIFF
--- a/src/strategies/instances/base/BaseDelayedStrategy.sol
+++ b/src/strategies/instances/base/BaseDelayedStrategy.sol
@@ -59,7 +59,8 @@ abstract contract BaseDelayedStrategy is
 
   /// @inheritdoc IERC165
   function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
-    return interfaceId == type(IEarnBalmyStrategy).interfaceId || interfaceId == type(IEarnStrategy).interfaceId;
+    return interfaceId == type(IEarnBalmyStrategy).interfaceId || interfaceId == type(IEarnStrategy).interfaceId
+      || interfaceId == type(IERC165).interfaceId;
   }
 
   /// @inheritdoc IEarnStrategy

--- a/src/strategies/instances/base/BaseStrategy.sol
+++ b/src/strategies/instances/base/BaseStrategy.sol
@@ -62,7 +62,8 @@ abstract contract BaseStrategy is
 
   /// @inheritdoc IERC165
   function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
-    return interfaceId == type(IEarnBalmyStrategy).interfaceId || interfaceId == type(IEarnStrategy).interfaceId;
+    return interfaceId == type(IEarnBalmyStrategy).interfaceId || interfaceId == type(IEarnStrategy).interfaceId
+      || interfaceId == type(IERC165).interfaceId;
   }
 
   /// @inheritdoc IEarnStrategy


### PR DESCRIPTION
This pull request adds support for the IERC165 interface to the BaseDelayedStrategy and BaseStrategy contracts. This allows these contracts to implement the IERC165 interface and indicate which interfaces they support.