### PR TITLE
fix: handle if total supply is zero

### DIFF
--- a/src/strategies/layers/connector/AaveV3Connector.sol
+++ b/src/strategies/layers/connector/AaveV3Connector.sol
@@ -210,20 +210,18 @@ abstract contract AaveV3Connector is BaseConnector, Initializable {
   {
     IAaveV3Rewards rewardsController = rewards();
     IAToken aToken_ = aToken();
-    uint256 totalAssets = aToken_.totalSupply();
+    uint256 totalAssets = Math.max(aToken_.totalSupply(), 1);
     address[] memory rewardsList = rewardsController.getRewardsByAsset(address(aToken_));
     emissions = new uint256[](rewardsList.length);
     multipliers = new uint256[](rewardsList.length);
-    if (totalAssets > 0) {
-      for (uint256 i; i < rewardsList.length; ++i) {
-        // slither-disable-next-line unused-return
-        (, uint256 emissionPerSecond,, uint256 distributionEnd) =
-          rewardsController.getRewardsData(address(aToken_), rewardsList[i]);
-        // slither-disable-next-line timestamp
-        if (block.timestamp <= distributionEnd) {
-          multipliers[i] = 1e30;
-          emissions[i] = emissionPerSecond.mulDiv(1e30, totalAssets, Math.Rounding.Floor);
-        }
+    for (uint256 i; i < rewardsList.length; ++i) {
+      // slither-disable-next-line unused-return
+      (, uint256 emissionPerSecond,, uint256 distributionEnd) =
+        rewardsController.getRewardsData(address(aToken_), rewardsList[i]);
+      // slither-disable-next-line timestamp
+      if (block.timestamp <= distributionEnd) {
+        multipliers[i] = 1e30;
+        emissions[i] = emissionPerSecond.mulDiv(1e30, totalAssets, Math.Rounding.Floor);
       }
     }
   }


### PR DESCRIPTION
We realized that if there were no assets, we should still expose the total emissions. But it would go entirely to whoever deposited tokens