### PR TITLE
feat: add events to rescue actions

### DIFF
--- a/src/guardian-manager/GuardianManager.sol
+++ b/src/guardian-manager/GuardianManager.sol
@@ -96,21 +96,21 @@ contract GuardianManager is IGuardianManager, AccessControlDefaultAdminRules {
       _assignJudges(strategyId, judges);
     }
   }
-  // solhint-disable no-empty-blocks
   /// @inheritdoc IGuardianManagerCore
 
   function rescueStarted(StrategyId strategyId) external {
-    // Does nothing, but we we want to have this function for future guardian manager implementations
+    emit RescueStarted(strategyId);
   }
   /// @inheritdoc IGuardianManagerCore
+
   function rescueCancelled(StrategyId strategyId) external {
-    // Does nothing, but we we want to have this function for future guardian manager implementations
+    emit RescueCancelled(strategyId);
   }
   /// @inheritdoc IGuardianManagerCore
+
   function rescueConfirmed(StrategyId strategyId) external {
-    // Does nothing, but we we want to have this function for future guardian manager implementations
+    emit RescueConfirmed(strategyId);
   }
-  // solhint-disable-end no-empty-blocks
 
   /// @inheritdoc IGuardianManager
   function assignGuardians(

--- a/src/interfaces/IGuardianManager.sol
+++ b/src/interfaces/IGuardianManager.sol
@@ -39,6 +39,9 @@ interface IGuardianManagerCore {
 }
 
 interface IGuardianManager is IGuardianManagerCore {
+  event RescueStarted(StrategyId strategyId);
+  event RescueCancelled(StrategyId strategyId);
+  event RescueConfirmed(StrategyId strategyId);
   event GuardiansAssigned(StrategyId strategyId, address[] accounts);
   event GuardiansRemoved(StrategyId strategyId, address[] accounts);
   event JudgesAssigned(StrategyId strategyId, address[] accounts);

--- a/test/unit/guardian-manager/GuardianManager.t.sol
+++ b/test/unit/guardian-manager/GuardianManager.t.sol
@@ -13,6 +13,9 @@ import { CommonUtils } from "../../utils/CommonUtils.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/extensions/IAccessControlDefaultAdminRules.sol";
 
 contract GuardianManagerTest is PRBTest {
+  event RescueStarted(StrategyId strategyId);
+  event RescueCancelled(StrategyId strategyId);
+  event RescueConfirmed(StrategyId strategyId);
   event GuardiansAssigned(StrategyId strategyId, address[] accounts);
   event GuardiansRemoved(StrategyId strategyId, address[] accounts);
   event JudgesAssigned(StrategyId strategyId, address[] accounts);
@@ -151,18 +154,24 @@ contract GuardianManagerTest is PRBTest {
   }
 
   function test_rescueStarted() public {
-    // Make sure it can be called without reverting
-    manager.rescueStarted(StrategyId.wrap(1));
+    StrategyId strategyId = StrategyId.wrap(1);
+    vm.expectEmit();
+    emit RescueStarted(strategyId);
+    manager.rescueStarted(strategyId);
   }
 
   function test_rescueCancelled() public {
-    // Make sure it can be called without reverting
-    manager.rescueCancelled(StrategyId.wrap(1));
+    StrategyId strategyId = StrategyId.wrap(1);
+    vm.expectEmit();
+    emit RescueCancelled(strategyId);
+    manager.rescueCancelled(strategyId);
   }
 
   function test_rescueConfirmed() public {
-    // Make sure it can be called without reverting
-    manager.rescueConfirmed(StrategyId.wrap(1));
+    StrategyId strategyId = StrategyId.wrap(1);
+    vm.expectEmit();
+    emit RescueConfirmed(strategyId);
+    manager.rescueConfirmed(strategyId);
   }
 
   function test_assignGuardians() public {


### PR DESCRIPTION
We are now emitting events when rescues are started/cancelled/confirmed. While we won't be doing anything with this information now, it might be helpful in the future