### PR TITLE
fix: set companion address as signature

### DIFF
--- a/src/companion/EarnVaultCompanion.sol
+++ b/src/companion/EarnVaultCompanion.sol
@@ -73,8 +73,8 @@ contract EarnVaultCompanion is BaseCompanion, IERC1271 {
       }
       value = depositAmount;
     }
-    // We will pass the strategy's address as the validation data so that we can verify it in `isValidSignature`
-    bytes memory newValidationData = abi.encode(strategy);
+    // We will pass the companion's address as the validation data so that we can verify it in `isValidSignature`
+    bytes memory newValidationData = abi.encode(address(this));
     // slither-disable-next-line arbitrary-send-eth,unused-return (not sure why this is necessary)
     return vault.createPosition{ value: value }({
       strategyId: strategyId,
@@ -188,8 +188,8 @@ contract EarnVaultCompanion is BaseCompanion, IERC1271 {
   }
 
   function isValidSignature(bytes32, bytes memory signature) external view override returns (bytes4) {
-    // We will only consider a signature valid if it is the address of the sender
-    address strategy = abi.decode(signature, (address));
-    return strategy == msg.sender ? IERC1271.isValidSignature.selector : bytes4(0);
+    // We will only consider a signature valid if it is this contract's address
+    address companion = abi.decode(signature, (address));
+    return companion == address(this) ? IERC1271.isValidSignature.selector : bytes4(0);
   }
 }

--- a/test/unit/companion/EarnVaultCompanion.t.sol
+++ b/test/unit/companion/EarnVaultCompanion.t.sol
@@ -88,7 +88,7 @@ contract EarnVaultCompanionTest is Test {
         depositAmount,
         owner,
         permissions,
-        abi.encode(address(strategy)),
+        abi.encode(address(companion)),
         misc
       )
     );
@@ -142,7 +142,7 @@ contract EarnVaultCompanionTest is Test {
         depositAmount,
         owner,
         permissions,
-        abi.encode(address(strategy)),
+        abi.encode(address(companion)),
         misc
       )
     );
@@ -195,7 +195,7 @@ contract EarnVaultCompanionTest is Test {
         depositAmount,
         owner,
         permissions,
-        abi.encode(address(strategy)),
+        abi.encode(address(companion)),
         misc
       )
     );
@@ -450,7 +450,7 @@ contract EarnVaultCompanionTest is Test {
 
   function test_isValidSignature_valid() public {
     bytes32 hash;
-    bytes memory signature = abi.encode(address(this));
+    bytes memory signature = abi.encode(address(companion));
     bytes4 result = companion.isValidSignature(hash, signature);
     assertEq(result, IERC1271.isValidSignature.selector);
   }


### PR DESCRIPTION
When we build the `isSignatureValid`, we expected TOS to be managed by strategies directly. But we then build the TOS manager, and the validation method didn't work for that case

Now we are making a change that would allow the method to work in all cases