### PR TITLE
fix: only strategies can alert of status change

### DIFF
--- a/src/strategies/layers/guardian/external/GuardianManager.sol
+++ b/src/strategies/layers/guardian/external/GuardianManager.sol
@@ -98,17 +98,17 @@ contract GuardianManager is IGuardianManager, AccessControlDefaultAdminRules {
   }
   /// @inheritdoc IGuardianManagerCore
 
-  function rescueStarted(StrategyId strategyId) external {
+  function rescueStarted(StrategyId strategyId) external onlyStrategy(strategyId) {
     emit RescueStarted(strategyId);
   }
   /// @inheritdoc IGuardianManagerCore
 
-  function rescueCancelled(StrategyId strategyId) external {
+  function rescueCancelled(StrategyId strategyId) external onlyStrategy(strategyId) {
     emit RescueCancelled(strategyId);
   }
   /// @inheritdoc IGuardianManagerCore
 
-  function rescueConfirmed(StrategyId strategyId) external {
+  function rescueConfirmed(StrategyId strategyId) external onlyStrategy(strategyId) {
     emit RescueConfirmed(strategyId);
   }
 
@@ -172,5 +172,13 @@ contract GuardianManager is IGuardianManager, AccessControlDefaultAdminRules {
 
   function _key(StrategyId strategyId, address account) internal pure returns (bytes32) {
     return keccak256(abi.encodePacked(strategyId, account));
+  }
+
+  modifier onlyStrategy(StrategyId strategyId) {
+    IEarnStrategy strategy = STRATEGY_REGISTRY.getStrategy(strategyId);
+    if (msg.sender != address(strategy)) {
+      revert UnauthorizedCaller();
+    }
+    _;
   }
 }

--- a/test/unit/strategies/layers/guardian/external/GuardianManager.t.sol
+++ b/test/unit/strategies/layers/guardian/external/GuardianManager.t.sol
@@ -155,22 +155,82 @@ contract GuardianManagerTest is PRBTest {
 
   function test_rescueStarted() public {
     StrategyId strategyId = StrategyId.wrap(1);
+    address strategy = address(4);
+
+    vm.mockCall(
+      address(registry),
+      abi.encodeWithSelector(IEarnStrategyRegistry.getStrategy.selector, strategyId),
+      abi.encode(strategy)
+    );
+
+    vm.prank(strategy);
     vm.expectEmit();
     emit RescueStarted(strategyId);
     manager.rescueStarted(strategyId);
   }
 
+  function test_rescueStarted_revertWhen_callerIsNotStrategy() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    vm.mockCall(
+      address(registry),
+      abi.encodeWithSelector(IEarnStrategyRegistry.getStrategy.selector, strategyId),
+      abi.encode(address(4))
+    );
+    vm.expectRevert(abi.encodeWithSelector(GuardianManager.UnauthorizedCaller.selector));
+    manager.rescueStarted(strategyId);
+  }
+
   function test_rescueCancelled() public {
     StrategyId strategyId = StrategyId.wrap(1);
+    address strategy = address(4);
+
+    vm.mockCall(
+      address(registry),
+      abi.encodeWithSelector(IEarnStrategyRegistry.getStrategy.selector, strategyId),
+      abi.encode(strategy)
+    );
+
+    vm.prank(strategy);
     vm.expectEmit();
     emit RescueCancelled(strategyId);
     manager.rescueCancelled(strategyId);
   }
 
+  function test_rescueCancelled_revertWhen_callerIsNotStrategy() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    vm.mockCall(
+      address(registry),
+      abi.encodeWithSelector(IEarnStrategyRegistry.getStrategy.selector, strategyId),
+      abi.encode(address(4))
+    );
+    vm.expectRevert(abi.encodeWithSelector(GuardianManager.UnauthorizedCaller.selector));
+    manager.rescueCancelled(strategyId);
+  }
+
   function test_rescueConfirmed() public {
     StrategyId strategyId = StrategyId.wrap(1);
+    address strategy = address(4);
+
+    vm.mockCall(
+      address(registry),
+      abi.encodeWithSelector(IEarnStrategyRegistry.getStrategy.selector, strategyId),
+      abi.encode(strategy)
+    );
+
+    vm.prank(strategy);
     vm.expectEmit();
     emit RescueConfirmed(strategyId);
+    manager.rescueConfirmed(strategyId);
+  }
+
+  function test_rescueConfirmed_revertWhen_callerIsNotStrategy() public {
+    StrategyId strategyId = StrategyId.wrap(1);
+    vm.mockCall(
+      address(registry),
+      abi.encodeWithSelector(IEarnStrategyRegistry.getStrategy.selector, strategyId),
+      abi.encode(address(4))
+    );
+    vm.expectRevert(abi.encodeWithSelector(GuardianManager.UnauthorizedCaller.selector));
     manager.rescueConfirmed(strategyId);
   }
 


### PR DESCRIPTION
Initially, `rescueStarted`, `rescueCancelled` and `rescueConfirmed` did nothing. We later decided to add events to those functions, but we forgot to add any kind of access control

We are now making sure that those functions can only be called by the strategy