### PR TITLE
fix: disable migrations during rescue

### DIFF
--- a/src/strategies/instances/base/BaseStrategy.sol
+++ b/src/strategies/instances/base/BaseStrategy.sol
@@ -188,7 +188,7 @@ abstract contract BaseStrategy is
     returns (bytes memory)
   {
     _strategyId = StrategyIdConstants.NO_STRATEGY;
-    return _connector_migrateToNewStrategy(newStrategy, migrationData);
+    return _guardian_migrateToNewStrategy(newStrategy, migrationData);
   }
 
   /// @inheritdoc IEarnStrategy
@@ -422,6 +422,17 @@ abstract contract BaseStrategy is
     )
   {
     return _connector_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
+  }
+
+  function _guardian_underlying_migrateToNewStrategy(
+    IEarnStrategy newStrategy,
+    bytes calldata migrationData
+  )
+    internal
+    override
+    returns (bytes memory)
+  {
+    return _connector_migrateToNewStrategy(newStrategy, migrationData);
   }
 
   ////////////////////////////////////////////////////////

--- a/src/strategies/layers/guardian/base/BaseGuardian.sol
+++ b/src/strategies/layers/guardian/base/BaseGuardian.sol
@@ -53,6 +53,13 @@ abstract contract BaseGuardian {
       uint256[] memory actualWithdrawnAmounts,
       bytes memory result
     );
+  function _guardian_underlying_migrateToNewStrategy(
+    IEarnStrategy newStrategy,
+    bytes calldata migrationData
+  )
+    internal
+    virtual
+    returns (bytes memory);
 
   // Guardian
   function _guardian_totalBalances() internal view virtual returns (address[] memory tokens, uint256[] memory balances);
@@ -87,5 +94,12 @@ abstract contract BaseGuardian {
       uint256[] memory actualWithdrawnAmounts,
       bytes memory result
     );
+  function _guardian_migrateToNewStrategy(
+    IEarnStrategy newStrategy,
+    bytes calldata migrationData
+  )
+    internal
+    virtual
+    returns (bytes memory);
   // slither-disable-end naming-convention
 }

--- a/src/strategies/layers/guardian/external/ExternalGuardian.sol
+++ b/src/strategies/layers/guardian/external/ExternalGuardian.sol
@@ -249,6 +249,21 @@ abstract contract ExternalGuardian is BaseGuardian, Initializable {
     return _guardian_underlying_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
   }
 
+  // slither-disable-next-line naming-convention,dead-code
+  function _guardian_migrateToNewStrategy(
+    IEarnStrategy newStrategy,
+    bytes calldata migrationData
+  )
+    internal
+    override
+    returns (bytes memory)
+  {
+    if (rescueConfig.status != RescueStatus.OK) {
+      revert InvalidRescueStatus();
+    }
+    return _guardian_underlying_migrateToNewStrategy(newStrategy, migrationData);
+  }
+
   // slither-disable-next-line dead-code
   function _getGuardianManager() private view returns (IGuardianManagerCore) {
     return IGuardianManagerCore(globalRegistry().getAddressOrFail(GUARDIAN_MANAGER));


### PR DESCRIPTION
Before this change, we weren't considering the rescue status of a strategy during a migration. This could lead to inconsistent states. For example, assets rescued might be lost during the migration. 

We've decided to simply disable migrations on strategies that:
- Have an unconfirmed rescue
- Have a confirmed rescue

Only strategies that don't have a confirmed or ongoing strategies will be migrated