### PR TITLE
fix: assert token is eth on steth adapter

### DIFF
--- a/src/strategies/layers/connector/lido/LidoSTETHDelayedWithdrawalAdapter.sol
+++ b/src/strategies/layers/connector/lido/LidoSTETHDelayedWithdrawalAdapter.sol
@@ -38,6 +38,8 @@ struct WithdrawalRequestStatus {
 }
 
 contract LidoSTETHDelayedWithdrawalAdapter is IDelayedWithdrawalAdapter {
+  error TokenNotETH();
+
   using Math for uint256;
   using SafeERC20 for IERC20;
 
@@ -120,7 +122,10 @@ contract LidoSTETHDelayedWithdrawalAdapter is IDelayedWithdrawalAdapter {
     }
   }
 
-  function initiateDelayedWithdrawal(uint256 positionId, address, uint256) external override {
+  function initiateDelayedWithdrawal(uint256 positionId, address token, uint256) external override {
+    if (token != _ETH) {
+      revert TokenNotETH();
+    }
     IDelayedWithdrawalManager delayedWithdrawalManager = manager();
     IEarnVault vault_ = delayedWithdrawalManager.VAULT();
     // slither-disable-next-line unused-return
@@ -146,7 +151,7 @@ contract LidoSTETHDelayedWithdrawalAdapter is IDelayedWithdrawalAdapter {
   // slither-disable-start assembly
   function withdraw(
     uint256 positionId,
-    address,
+    address token,
     address recipient
   )
     external
@@ -154,6 +159,9 @@ contract LidoSTETHDelayedWithdrawalAdapter is IDelayedWithdrawalAdapter {
     onlyManager
     returns (uint256 withdrawn, uint256 stillPending)
   {
+    if (token != _ETH) {
+      revert TokenNotETH();
+    }
     uint256[] memory requestIds = _pendingWithdrawals[positionId];
     if (requestIds.length == 0) {
       return (0, 0);

--- a/test/integration/strategies/layers/connector/lido/LidoSTETHDelayedWithdrawalAdapter.t.sol
+++ b/test/integration/strategies/layers/connector/lido/LidoSTETHDelayedWithdrawalAdapter.t.sol
@@ -89,19 +89,30 @@ contract LidoSTETHDelayedWithdrawalAdapterTest is PRBTest {
     assertEq(pendingAmount, 0);
   }
 
+  function testFork_initiateDelayedWithdrawal_RevertWhen_tokenIsNotETH() public {
+    vm.expectRevert(LidoSTETHDelayedWithdrawalAdapter.TokenNotETH.selector);
+    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, address(1), 1000);
+  }
+
   function testFork_initiateDelayedWithdrawal() public {
     uint256 amount = 1000;
     vm.prank(stETH_TOKEN_HOLDER);
     IERC20(_stETH).transfer(address(lidoSTETHDelayedWithdrawalAdapter), uint256(amount));
     vm.startPrank(address(strategy));
 
-    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, owner, amount);
+    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, Token.NATIVE_TOKEN, amount);
     // Make sure that the adapter doesn't have any funds for other tokens
     uint256 pendingAmount = lidoSTETHDelayedWithdrawalAdapter.estimatedPendingFunds(position, Token.NATIVE_TOKEN);
     assertAlmostEq(pendingAmount, amount, 2);
     assertEq(lidoSTETHDelayedWithdrawalAdapter.estimatedPendingFunds(position, address(1)), 0);
 
     vm.stopPrank();
+  }
+
+  function testFork_withdraw_RevertWhen_tokenIsNotETH() public {
+    vm.prank(address(lidoSTETHDelayedWithdrawalAdapter.manager()));
+    vm.expectRevert(LidoSTETHDelayedWithdrawalAdapter.TokenNotETH.selector);
+    lidoSTETHDelayedWithdrawalAdapter.withdraw(position, address(1), address(strategy));
   }
 
   function testFork_withdraw() public {
@@ -112,7 +123,7 @@ contract LidoSTETHDelayedWithdrawalAdapterTest is PRBTest {
     IERC20(_stETH).transfer(address(lidoSTETHDelayedWithdrawalAdapter), uint256(amount));
 
     vm.startPrank(address(strategy));
-    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, owner, amount);
+    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, Token.NATIVE_TOKEN, amount);
 
     // Force the delayed to be finalized
     queue.setTimeToWithdraw(true);
@@ -143,8 +154,8 @@ contract LidoSTETHDelayedWithdrawalAdapterTest is PRBTest {
 
     vm.startPrank(address(strategy));
 
-    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, owner, amount / 2);
-    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, owner, amount / 2);
+    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, Token.NATIVE_TOKEN, amount / 2);
+    lidoSTETHDelayedWithdrawalAdapter.initiateDelayedWithdrawal(position, Token.NATIVE_TOKEN, amount / 2);
 
     // Force the delayed to be finalized
     queue.setTimeToWithdraw(true);


### PR DESCRIPTION
We now make sure to return 0 or revert when the given token is not ETH