### PR TITLE
fix: round down for special withdraw erc4626

### DIFF
--- a/src/strategies/layers/connector/ERC4626Connector.sol
+++ b/src/strategies/layers/connector/ERC4626Connector.sol
@@ -214,7 +214,7 @@ abstract contract ERC4626Connector is BaseConnector, Initializable {
       actualWithdrawnAmounts[0] = shares;
     } else if (withdrawalCode == SpecialWithdrawal.WITHDRAW_ASSET_FARM_TOKEN_BY_ASSET_AMOUNT) {
       uint256 assets = toWithdraw[0];
-      uint256 shares = vault.previewWithdraw(assets);
+      uint256 shares = vault.convertToShares(assets);
       vault.safeTransfer(recipient, shares);
       balanceChanges[0] = assets;
       actualWithdrawnTokens[0] = address(vault);


### PR DESCRIPTION
When the user performs a withdrawal (either special or not), we should always try to round in a direction that doesn't favor the user. The thing is that `previewWithdraw` does round up when calculating how many shares are burned from the withdraw. So we should try to do something different