### PR TITLE
refactor: rename deposit to deposited

### DIFF
--- a/src/strategies/instances/base/BaseDelayedStrategy.sol
+++ b/src/strategies/instances/base/BaseDelayedStrategy.sol
@@ -318,7 +318,7 @@ abstract contract BaseDelayedStrategy is
     override
     returns (uint256 assetsDeposited)
   {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposited(depositToken, depositAmount);
   }
 
   function _fees_underlying_withdraw(

--- a/src/strategies/instances/base/BaseStrategy.sol
+++ b/src/strategies/instances/base/BaseStrategy.sol
@@ -389,7 +389,7 @@ abstract contract BaseStrategy is
     override
     returns (uint256 assetsDeposited)
   {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposited(depositToken, depositAmount);
   }
 
   function _guardian_underlying_withdraw(

--- a/src/strategies/layers/connector/AaveV2Connector.sol
+++ b/src/strategies/layers/connector/AaveV2Connector.sol
@@ -132,7 +132,7 @@ abstract contract AaveV2Connector is BaseConnector, Initializable {
   }
 
   // slither-disable-next-line naming-convention,dead-code
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/src/strategies/layers/connector/AaveV3Connector.sol
+++ b/src/strategies/layers/connector/AaveV3Connector.sol
@@ -191,7 +191,7 @@ abstract contract AaveV3Connector is BaseConnector, Initializable {
   }
 
   // slither-disable-next-line naming-convention,dead-code
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/src/strategies/layers/connector/BeefyConnector.sol
+++ b/src/strategies/layers/connector/BeefyConnector.sol
@@ -131,7 +131,7 @@ abstract contract BeefyConnector is BaseConnector, Initializable {
   }
 
   // slither-disable-next-line naming-convention,dead-code
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/src/strategies/layers/connector/ERC4626Connector.sol
+++ b/src/strategies/layers/connector/ERC4626Connector.sol
@@ -142,7 +142,7 @@ abstract contract ERC4626Connector is BaseConnector, Initializable {
   { }
 
   // slither-disable-next-line naming-convention,dead-code
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/src/strategies/layers/connector/base/BaseConnector.sol
+++ b/src/strategies/layers/connector/base/BaseConnector.sol
@@ -38,7 +38,7 @@ abstract contract BaseConnector {
     virtual
     returns (address[] memory tokens, uint256[] memory balances);
   function _connector_delayedWithdrawalAdapter(address token) internal view virtual returns (IDelayedWithdrawalAdapter);
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/src/strategies/layers/connector/compound-v2/CompoundV2Connector.sol
+++ b/src/strategies/layers/connector/compound-v2/CompoundV2Connector.sol
@@ -162,7 +162,7 @@ abstract contract CompoundV2Connector is BaseConnector, Initializable {
   }
 
   // slither-disable-next-line naming-convention,dead-code
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/src/strategies/layers/connector/lido/LidoSTETHConnector.sol
+++ b/src/strategies/layers/connector/lido/LidoSTETHConnector.sol
@@ -60,7 +60,7 @@ abstract contract LidoSTETHConnector is BaseConnector, Initializable {
   }
 
   // slither-disable-next-line naming-convention,dead-code
-  function _connector_deposit(
+  function _connector_deposited(
     address depositToken,
     uint256 depositAmount
   )

--- a/test/integration/strategies/layers/connector/base/BaseConnectorInstance.sol
+++ b/test/integration/strategies/layers/connector/base/BaseConnectorInstance.sol
@@ -55,7 +55,7 @@ abstract contract BaseConnectorInstance is BaseConnector {
   }
 
   function deposit(address depositToken, uint256 depositAmount) external returns (uint256 assetsDeposited) {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposited(depositToken, depositAmount);
   }
 
   function withdraw(

--- a/test/mocks/strategies/LidoSTETHStrategyMock.sol
+++ b/test/mocks/strategies/LidoSTETHStrategyMock.sol
@@ -115,7 +115,7 @@ contract LidoSTETHStrategyMock is IEarnBalmyStrategy, LidoSTETHConnector {
 
   /// @inheritdoc IEarnStrategy
   function deposited(address depositToken, uint256 depositAmount) external payable returns (uint256 assetsDeposited) {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposited(depositToken, depositAmount);
   }
 
   /// @inheritdoc IEarnStrategy


### PR DESCRIPTION
The public function is called `deposited` because funds are already on the strategy, so it makes sense to use the same name on the connector