### PR TITLE
fix: handle native excess when setting campaign

### DIFF
--- a/src/interfaces/ILiquidityMiningManager.sol
+++ b/src/interfaces/ILiquidityMiningManager.sol
@@ -91,6 +91,14 @@ interface ILiquidityMiningManager is ILiquidityMiningManagerCore {
   function MANAGE_CAMPAIGNS_ROLE() external view returns (bytes32);
   // slither-disable-end naming-convention
 
+  /**
+   * @notice Sets a campaign for a given strategy
+   * @param strategyId The id of the strategy
+   * @param reward The reward token for the campaign
+   * @param emissionPerSecond The emission per second for the campaign
+   * @param duration The duration of the campaign
+   * @dev In the case of a native reward token, any excess funds will be returned to the caller
+   */
   function setCampaign(
     StrategyId strategyId,
     address reward,

--- a/test/unit/strategies/layers/liquidity-mining/external/LiquidityMiningManager.t.sol
+++ b/test/unit/strategies/layers/liquidity-mining/external/LiquidityMiningManager.t.sol
@@ -139,6 +139,24 @@ contract LiquidityMiningManagerTest is PRBTest, StdCheats {
     assertEq(address(manager).balance, balanceForCampaign);
   }
 
+  function test_setCampaign_NativeExcessFundsAreReturned() public {
+    vm.startPrank(adminManageCampaigns);
+    uint256 balanceForCampaign = 3 * 10;
+    uint256 previousBalance = address(adminManageCampaigns).balance;
+    vm.expectEmit();
+    emit CampaignSet(strategyId, Token.NATIVE_TOKEN, 3, block.timestamp + 10);
+    // Make sure it can be called without reverting
+    manager.setCampaign{ value: balanceForCampaign + 10 }({
+      strategyId: strategyId,
+      reward: Token.NATIVE_TOKEN,
+      emissionPerSecond: 3,
+      duration: 10
+    });
+    vm.stopPrank();
+    assertEq(address(adminManageCampaigns).balance, previousBalance - balanceForCampaign);
+    assertEq(address(manager).balance, balanceForCampaign);
+  }
+
   function test_setCampaign_modifyCampaign_addBalance_Native() public {
     vm.startPrank(adminManageCampaigns);
     uint256 balanceForCampaign = 3 * 10;


### PR DESCRIPTION
Setting a campaign can be tricky because maybe the campaign is already active, so the current funds change every second. And it's specially difficult in the case of the native token

Before this change, we would force `msg.value == needed`, which is almost impossible for an active campaign. Now, we make sure that `msg.value > needed`, and we will transfer back any excess funds to the caller