### PR TITLE
refactor: call manager consistently

### DIFF
--- a/src/strategies/layers/liquidity-mining/external/ExternalLiquidityMining.sol
+++ b/src/strategies/layers/liquidity-mining/external/ExternalLiquidityMining.sol
@@ -131,12 +131,12 @@ abstract contract ExternalLiquidityMining is BaseLiquidityMining, Initializable 
   )
     private
   {
+    toWithdrawUnderlying[0] = toWithdrawAsset;
+    _liquidity_mining_underlying_withdraw(positionId, underlyingTokens, toWithdrawUnderlying, recipient);
     if (toWithdrawAsset > 0) {
       // Only call withdrew if we are withdrawing the asset
       manager.withdrew(strategyId_, toWithdrawAsset);
     }
-    toWithdrawUnderlying[0] = toWithdrawAsset;
-    _liquidity_mining_underlying_withdraw(positionId, underlyingTokens, toWithdrawUnderlying, recipient);
   }
 
   // slither-disable-next-line naming-convention,dead-code
@@ -160,7 +160,9 @@ abstract contract ExternalLiquidityMining is BaseLiquidityMining, Initializable 
     (underlyingBalanceChanges, actualWithdrawnTokens, actualWithdrawnAmounts, result) =
       _liquidity_mining_underlying_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
     ILiquidityMiningManagerCore manager = _getLiquidityMiningManager();
-    manager.withdrew(strategyId(), underlyingBalanceChanges[0]);
+    if (underlyingBalanceChanges[0] > 0) {
+      manager.withdrew(strategyId(), underlyingBalanceChanges[0]);
+    }
     address[] memory tokens = _liquidity_mining_allTokens();
     if (tokens.length == underlyingBalanceChanges.length) {
       balanceChanges = underlyingBalanceChanges;


### PR DESCRIPTION
Before the change, the call order was the following:
- `deposit`:  `underlying_deposited` => `manager.deposited`
- `withdraw`: `manager.withdrew` => `underlying_withdraw`
- `specialWithdraw`: `underlying_specialWithdraw` => `manager.withdrew`

So now we are making two changes:
1. In the case of `withdraw`, we are calling the manager after the underlying layer is called
2. In `specialWithdraw`, we only call the manager if the amount of withdrawn assets is more than 0 (like in the case of `withdraw`)
