### PR TITLE
fix: add reentrancy lock to special withdraw fees

### DIFF
--- a/src/strategies/layers/fees/external/ExternalFees.sol
+++ b/src/strategies/layers/fees/external/ExternalFees.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IEarnStrategy, SpecialWithdrawalCode } from "@balmy/earn-core/interfaces/IEarnStrategy.sol";
 import { IGlobalEarnRegistry } from "src/interfaces/IGlobalEarnRegistry.sol";
@@ -9,7 +10,7 @@ import { IFeeManagerCore, StrategyId, Fees } from "src/interfaces/IFeeManager.so
 import { BaseFees } from "../base/BaseFees.sol";
 
 /// @dev This fees layer implementation only supports performance fees
-abstract contract ExternalFees is BaseFees, Initializable {
+abstract contract ExternalFees is BaseFees, ReentrancyGuard, Initializable {
   error CantWithdrawFees();
   error NotEnoughFees();
   error WithdrawMustBeImmediate();
@@ -70,6 +71,7 @@ abstract contract ExternalFees is BaseFees, Initializable {
     address recipient
   )
     external
+    nonReentrant
     returns (
       uint256[] memory balanceChanges,
       address[] memory actualWithdrawnTokens,


### PR DESCRIPTION
`specialWithdrawFees` is open to a potential reentrancy attack. Since we can't use CEI for this function, we'll add a reentrancy lock