### PR TITLE
fix: avoid modifying validation data on companion

### DIFF
--- a/src/companion/EarnVaultCompanion.sol
+++ b/src/companion/EarnVaultCompanion.sol
@@ -73,8 +73,6 @@ contract EarnVaultCompanion is BaseCompanion, IERC1271 {
       }
       value = depositAmount;
     }
-    // We will pass the companion's address as the validation data so that we can verify it in `isValidSignature`
-    bytes memory newValidationData = abi.encode(address(this));
     // slither-disable-next-line arbitrary-send-eth,unused-return (not sure why this is necessary)
     return vault.createPosition{ value: value }({
       strategyId: strategyId,
@@ -82,7 +80,7 @@ contract EarnVaultCompanion is BaseCompanion, IERC1271 {
       depositAmount: depositAmount,
       owner: owner_,
       permissions: permissions,
-      strategyValidationData: newValidationData,
+      strategyValidationData: strategyValidationData,
       misc: misc
     });
   }
@@ -187,9 +185,8 @@ contract EarnVaultCompanion is BaseCompanion, IERC1271 {
     _;
   }
 
-  function isValidSignature(bytes32, bytes memory signature) external view override returns (bytes4) {
-    // We will only consider a signature valid if it is this contract's address
-    address companion = abi.decode(signature, (address));
-    return companion == address(this) ? IERC1271.isValidSignature.selector : bytes4(0);
+  function isValidSignature(bytes32, bytes calldata) external pure override returns (bytes4) {
+    // We'll always consider a signature valid, since we don't have a way to understand exactly what was signed
+    return IERC1271.isValidSignature.selector;
   }
 }

--- a/test/unit/companion/EarnVaultCompanion.t.sol
+++ b/test/unit/companion/EarnVaultCompanion.t.sol
@@ -88,7 +88,7 @@ contract EarnVaultCompanionTest is Test {
         depositAmount,
         owner,
         permissions,
-        abi.encode(address(companion)),
+        validationData,
         misc
       )
     );
@@ -142,7 +142,7 @@ contract EarnVaultCompanionTest is Test {
         depositAmount,
         owner,
         permissions,
-        abi.encode(address(companion)),
+        validationData,
         misc
       )
     );
@@ -195,7 +195,7 @@ contract EarnVaultCompanionTest is Test {
         depositAmount,
         owner,
         permissions,
-        abi.encode(address(companion)),
+        validationData,
         misc
       )
     );
@@ -448,18 +448,11 @@ contract EarnVaultCompanionTest is Test {
     assertEq(result, expectedResult);
   }
 
-  function test_isValidSignature_valid() public {
+  function test_isValidSignature() public {
     bytes32 hash;
     bytes memory signature = abi.encode(address(companion));
     bytes4 result = companion.isValidSignature(hash, signature);
     assertEq(result, IERC1271.isValidSignature.selector);
-  }
-
-  function test_isValidSignature_invalid() public {
-    bytes32 hash;
-    bytes memory signature = abi.encode(10);
-    bytes4 result = companion.isValidSignature(hash, signature);
-    assertNotEq(result, IERC1271.isValidSignature.selector);
   }
 }
 


### PR DESCRIPTION
We realized that while the current code worked, it would only work with the current ToS validation. If we wanted to perform any other validation in the future, then we wouldn't be able to make it work since the Companion would overwrite the data
So we are not overwriting things any more