### PR TITLE
fix: add reentrancy check to delayed withdrawal manager

### DIFF
--- a/src/delayed-withdrawal-manager/DelayedWithdrawalManager.sol
+++ b/src/delayed-withdrawal-manager/DelayedWithdrawalManager.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.22;
 
 import { INFTPermissions } from "@balmy/nft-permissions/interfaces/INFTPermissions.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-
 import { IDelayedWithdrawalManager, IEarnVault } from "../interfaces/IDelayedWithdrawalManager.sol";
 import { IDelayedWithdrawalAdapter } from "../interfaces/IDelayedWithdrawalAdapter.sol";
 import { StrategyId, StrategyIdConstants } from "@balmy/earn-core/types/StrategyId.sol";


### PR DESCRIPTION
Since `withdraw` makes an external call before updating the state, we are now adding some reentrancy checks