### PR TITLE
feat: add global validation managers registry

### DIFF
--- a/src/interfaces/IValidationManagersRegistry.sol
+++ b/src/interfaces/IValidationManagersRegistry.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.8;
+
+import { StrategyId } from "@balmy/earn-core/interfaces/IEarnStrategy.sol";
+import { ICreationValidationManagerCore } from "./ICreationValidationManager.sol";
+
+interface IValidationManagersRegistryCore {
+  /**
+   * @notice Allows the strategy to call the registry, for self-configuration
+   */
+  function strategySelfConfigure(bytes calldata data) external;
+
+  /**
+   * @notice Returns the list of registered managers for the given strategy
+   * @param strategyId The id of the strategy
+   * @return The managers
+   */
+  function getManagers(StrategyId strategyId) external view returns (ICreationValidationManagerCore[] memory);
+}
+
+interface IValidationManagersRegistry is IValidationManagersRegistryCore {
+  /**
+   * @notice Emitted when the managers are set
+   * @param managers The manager addresses
+   */
+  event ManagersSet(ICreationValidationManagerCore[] managers);
+
+  /**
+   * @notice Sets the managers for all strategies
+   * @param managers The managers
+   */
+  function setManagers(ICreationValidationManagerCore[] memory managers) external;
+}

--- a/src/strategies/layers/creation-validation/external/GlobalValidationManagersRegistry.sol
+++ b/src/strategies/layers/creation-validation/external/GlobalValidationManagersRegistry.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.22;
+
+import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {
+  IValidationManagersRegistry,
+  IValidationManagersRegistryCore,
+  ICreationValidationManagerCore,
+  StrategyId
+} from "src/interfaces/IValidationManagersRegistry.sol";
+
+/// @notice This registry will use the same list of managers for all strategies
+contract GlobalValidationManagersRegistry is IValidationManagersRegistry, Ownable2Step {
+  ICreationValidationManagerCore[] private _managers;
+
+  constructor(ICreationValidationManagerCore[] memory managers, address owner_) Ownable(owner_) {
+    _managers = managers;
+    emit ManagersSet(managers);
+  }
+
+  /// @inheritdoc IValidationManagersRegistryCore
+  function getManagers(StrategyId) external view returns (ICreationValidationManagerCore[] memory) {
+    return _managers;
+  }
+
+  /// @inheritdoc IValidationManagersRegistryCore
+  // solhint-disable-next-line no-empty-blocks
+  function strategySelfConfigure(bytes calldata) external {
+    // We'll do nothing here, but we need to implement it to satisfy the interface
+  }
+
+  /// @inheritdoc IValidationManagersRegistry
+  function setManagers(ICreationValidationManagerCore[] memory managers) external onlyOwner {
+    _managers = managers;
+    emit ManagersSet(managers);
+  }
+}

--- a/test/unit/strategies/layers/creation-validation/external/GlobalValidationManagersRegistry.t.sol
+++ b/test/unit/strategies/layers/creation-validation/external/GlobalValidationManagersRegistry.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.22;
+
+// solhint-disable no-unused-import
+import { Test } from "forge-std/Test.sol";
+import {
+  IValidationManagersRegistry,
+  GlobalValidationManagersRegistry,
+  StrategyId,
+  ICreationValidationManagerCore,
+  Ownable
+} from "src/strategies/layers/creation-validation/external/GlobalValidationManagersRegistry.sol";
+import { CommonUtils } from "test/utils/CommonUtils.sol";
+
+contract GlobalValidationManagersRegistryTest is Test {
+  address private owner = address(1);
+  ICreationValidationManagerCore private initialManager1 = ICreationValidationManagerCore(address(2));
+  ICreationValidationManagerCore private initialManager2 = ICreationValidationManagerCore(address(3));
+  GlobalValidationManagersRegistry private registry;
+
+  function setUp() public virtual {
+    ICreationValidationManagerCore[] memory managers = _arrayOf(initialManager1, initialManager2);
+    vm.expectEmit();
+    emit IValidationManagersRegistry.ManagersSet(managers);
+    registry = new GlobalValidationManagersRegistry(managers, owner);
+  }
+
+  function test_constructor() public {
+    ICreationValidationManagerCore[] memory managers = registry.getManagers(StrategyId.wrap(0));
+    assertEq(managers.length, 2);
+    assertEq(address(managers[0]), address(initialManager1));
+    assertEq(address(managers[1]), address(initialManager2));
+
+    // Ownable
+    assertEq(registry.owner(), owner);
+  }
+
+  function test_setManagers() public {
+    ICreationValidationManagerCore newManager = ICreationValidationManagerCore(address(4));
+    ICreationValidationManagerCore[] memory newManagers = _arrayOf(newManager);
+    vm.expectEmit();
+    emit IValidationManagersRegistry.ManagersSet(newManagers);
+    vm.prank(owner);
+    registry.setManagers(newManagers);
+    ICreationValidationManagerCore[] memory managers = registry.getManagers(StrategyId.wrap(0));
+    assertEq(managers.length, 1);
+    assertEq(address(managers[0]), address(newManager));
+  }
+
+  function test_setManagers_revertsWhen_notOwner() public {
+    ICreationValidationManagerCore newManager = ICreationValidationManagerCore(address(4));
+    ICreationValidationManagerCore[] memory newManagers = _arrayOf(newManager);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(this)));
+    registry.setManagers(newManagers);
+  }
+
+  function test_strategySelfConfigure() public {
+    // Make sure it can be called, even though it does nothing
+    registry.strategySelfConfigure("");
+  }
+
+  function _arrayOf(ICreationValidationManagerCore manager)
+    internal
+    pure
+    returns (ICreationValidationManagerCore[] memory array)
+  {
+    array = new ICreationValidationManagerCore[](1);
+    array[0] = manager;
+  }
+
+  function _arrayOf(
+    ICreationValidationManagerCore manager1,
+    ICreationValidationManagerCore manager2
+  )
+    internal
+    pure
+    returns (ICreationValidationManagerCore[] memory array)
+  {
+    array = new ICreationValidationManagerCore[](2);
+    array[0] = manager1;
+    array[1] = manager2;
+  }
+}


### PR DESCRIPTION
We are now implementing `GlobalValidationManagersRegistry`. This registry will use the same list of managers for all strategies