### PR TITLE
feat: allow configuring global registry on deployment

### DIFF
--- a/src/global-registry/GlobalEarnRegistry.sol
+++ b/src/global-registry/GlobalEarnRegistry.sol
@@ -5,10 +5,19 @@ import { Ownable2Step, Ownable } from "@openzeppelin/contracts/access/Ownable2St
 import { IGlobalEarnRegistry } from "../interfaces/IGlobalEarnRegistry.sol";
 
 contract GlobalEarnRegistry is IGlobalEarnRegistry, Ownable2Step {
+  struct InitialConfig {
+    bytes32 id;
+    address contractAddress;
+  }
+
   /// @inheritdoc IGlobalEarnRegistry
   mapping(bytes32 id => address contractAddress) public getAddress;
 
-  constructor(address owner_) Ownable(owner_) { }
+  constructor(InitialConfig[] memory config, address owner_) Ownable(owner_) {
+    for (uint256 i = 0; i < config.length; ++i) {
+      _setAddress(config[i].id, config[i].contractAddress);
+    }
+  }
 
   /// @inheritdoc IGlobalEarnRegistry
   function getAddressOrFail(bytes32 id) external view returns (address) {
@@ -21,6 +30,10 @@ contract GlobalEarnRegistry is IGlobalEarnRegistry, Ownable2Step {
 
   /// @inheritdoc IGlobalEarnRegistry
   function setAddress(bytes32 id, address contractAddress) external onlyOwner {
+    _setAddress(id, contractAddress);
+  }
+
+  function _setAddress(bytes32 id, address contractAddress) internal {
     getAddress[id] = contractAddress;
     emit AddressSet(id, contractAddress);
   }

--- a/test/integration/strategies/layers/connector/lido/LidoSTETHDelayedWithdrawalAdapter.t.sol
+++ b/test/integration/strategies/layers/connector/lido/LidoSTETHDelayedWithdrawalAdapter.t.sol
@@ -48,7 +48,7 @@ contract LidoSTETHDelayedWithdrawalAdapterTest is PRBTest {
 
     queue = new LidoSTETHQueueMock();
 
-    globalRegistry = new GlobalEarnRegistry(address(this));
+    globalRegistry = new GlobalEarnRegistry(new GlobalEarnRegistry.InitialConfig[](0), address(this));
 
     IEarnStrategyRegistry strategyRegistry = new EarnStrategyRegistry();
     IEarnNFTDescriptor nftDescriptor = IEarnNFTDescriptor(address(this));

--- a/test/unit/global-registry/GlobalEarnRegistry.t.sol
+++ b/test/unit/global-registry/GlobalEarnRegistry.t.sol
@@ -10,11 +10,22 @@ contract GlobalEarnRegistryTest is PRBTest {
   event AddressSet(bytes32 indexed id, address contractAddress);
 
   bytes32 private constant ID_1 = keccak256("id 1");
+  bytes32 private constant ID_2 = keccak256("id 2");
   address private owner = address(1);
+  address private initialAddress = address(10);
+
   GlobalEarnRegistry private globalRegistry;
 
   function setUp() public virtual {
-    globalRegistry = new GlobalEarnRegistry(owner);
+    GlobalEarnRegistry.InitialConfig[] memory config = new GlobalEarnRegistry.InitialConfig[](1);
+    config[0] = GlobalEarnRegistry.InitialConfig({ id: ID_2, contractAddress: initialAddress });
+    vm.expectEmit();
+    emit IGlobalEarnRegistry.AddressSet(ID_2, initialAddress);
+    globalRegistry = new GlobalEarnRegistry(config, owner);
+  }
+
+  function test_constructor() public {
+    assertEq(globalRegistry.getAddress(ID_2), initialAddress);
   }
 
   function test_getAddress_NotSet() public {


### PR DESCRIPTION
We are now adding a way to configure the `GlobalEarnRegistry` during deployment