### PR TITLE
refactor: stop hardcoding manager key

### DIFF
--- a/src/strategies/layers/creation-validation/external/ExternalCreationValidation.sol
+++ b/src/strategies/layers/creation-validation/external/ExternalCreationValidation.sol
@@ -7,8 +7,8 @@ import { ICreationValidationManagerCore, StrategyId } from "src/interfaces/ICrea
 import { BaseCreationValidation } from "../base/BaseCreationValidation.sol";
 
 abstract contract ExternalCreationValidation is BaseCreationValidation, Initializable {
-  /// @notice The id for the Creation Validation Manager
-  bytes32 public constant CREATION_VALIDATION_MANAGER = keccak256("CREATION_VALIDATION_MANAGER");
+  /// @notice The key for the Creation Validation Manager
+  function validationManagerKey() public view virtual returns (bytes32);
 
   /// @notice The address of the global registry
   function globalRegistry() public view virtual returns (IGlobalEarnRegistry);
@@ -28,6 +28,6 @@ abstract contract ExternalCreationValidation is BaseCreationValidation, Initiali
 
   // slither-disable-next-line dead-code
   function _getCreationValidationManager() private view returns (ICreationValidationManagerCore) {
-    return ICreationValidationManagerCore(globalRegistry().getAddressOrFail(CREATION_VALIDATION_MANAGER));
+    return ICreationValidationManagerCore(globalRegistry().getAddressOrFail(validationManagerKey()));
   }
 }

--- a/test/unit/strategies/layers/creation-validation/external/ExternalCreationValidationTest.t.sol
+++ b/test/unit/strategies/layers/creation-validation/external/ExternalCreationValidationTest.t.sol
@@ -11,15 +11,18 @@ import {
 
 contract ExternalCreationValidationTest is Test {
   bytes32 private constant GROUP_1 = keccak256("group1");
+  bytes32 private constant VALIDATION_MANAGER_KEY = keccak256("validationManagerKey");
   ExternalCreationValidationInstance private validation;
   IGlobalEarnRegistry private registry = IGlobalEarnRegistry(address(1));
   ICreationValidationManagerCore private manager = ICreationValidationManagerCore(address(2));
   StrategyId private strategyId = StrategyId.wrap(1);
 
   function setUp() public virtual {
-    validation = new ExternalCreationValidationInstance(registry, strategyId);
+    validation = new ExternalCreationValidationInstance(registry, strategyId, VALIDATION_MANAGER_KEY);
     vm.mockCall(
-      address(registry), abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector), abi.encode(manager)
+      address(registry),
+      abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, VALIDATION_MANAGER_KEY),
+      abi.encode(manager)
     );
     vm.mockCall(
       address(manager),
@@ -52,10 +55,12 @@ contract ExternalCreationValidationTest is Test {
 contract ExternalCreationValidationInstance is ExternalCreationValidation {
   IGlobalEarnRegistry private _registry;
   StrategyId private _strategyId;
+  bytes32 private _validationManagerKey;
 
-  constructor(IGlobalEarnRegistry registry, StrategyId strategyId_) {
+  constructor(IGlobalEarnRegistry registry, StrategyId strategyId_, bytes32 validationManagerKey_) {
     _registry = registry;
     _strategyId = strategyId_;
+    _validationManagerKey = validationManagerKey_;
   }
 
   function init(bytes calldata data) external initializer {
@@ -72,5 +77,9 @@ contract ExternalCreationValidationInstance is ExternalCreationValidation {
 
   function strategyId() public view virtual override returns (StrategyId) {
     return _strategyId;
+  }
+
+  function validationManagerKey() public view virtual override returns (bytes32) {
+    return _validationManagerKey;
   }
 }


### PR DESCRIPTION
Since we now have multiple implementation of the validation manager, we will take the key from a function, instead of having it hardcoded