### PR TITLE
fix: send liq mining data on init

### DIFF
--- a/src/strategies/instances/aave-v2/AaveV2Strategy.sol
+++ b/src/strategies/instances/aave-v2/AaveV2Strategy.sol
@@ -30,13 +30,20 @@ contract AaveV2Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
     returns (StrategyId strategyId_)
   {
     strategyId_ = _baseStrategy_registerStrategy(owner);
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -45,12 +52,19 @@ contract AaveV2Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
   {
     _strategyId = strategyId_;
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -58,15 +72,17 @@ contract AaveV2Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     public
     initializer
   {
+    _connector_init();
     _creationValidation_init(creationValidationData);
     _guardian_init(guardianData);
     _fees_init(feesData);
-    _connector_init();
+    _liquidity_mining_init(liquidityMiningData);
     description = description_;
   }
 

--- a/src/strategies/instances/aave-v2/AaveV2StrategyFactory.sol
+++ b/src/strategies/instances/aave-v2/AaveV2StrategyFactory.sol
@@ -16,6 +16,7 @@ struct AaveV2StrategyData {
   bytes creationValidationData;
   bytes guardianData;
   bytes feesData;
+  bytes liquidityMiningData;
   string description;
 }
 
@@ -27,9 +28,13 @@ contract AaveV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = AaveV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function cloneStrategyAndRegister(
@@ -42,13 +47,14 @@ contract AaveV2StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = AaveV2Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -64,13 +70,14 @@ contract AaveV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = AaveV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2Strategy(
@@ -84,9 +91,13 @@ contract AaveV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = AaveV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2StrategyAndRegister(
@@ -100,13 +111,14 @@ contract AaveV2StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = AaveV2Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -123,13 +135,14 @@ contract AaveV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = AaveV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function addressOfClone2(

--- a/src/strategies/instances/aave-v3/AaveV3Strategy.sol
+++ b/src/strategies/instances/aave-v3/AaveV3Strategy.sol
@@ -32,13 +32,20 @@ contract AaveV3Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
     returns (StrategyId strategyId_)
   {
     strategyId_ = _baseStrategy_registerStrategy(owner);
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -47,12 +54,19 @@ contract AaveV3Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
   {
     _strategyId = strategyId_;
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -60,15 +74,17 @@ contract AaveV3Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     public
     initializer
   {
+    _connector_init();
     _creationValidation_init(creationValidationData);
     _guardian_init(guardianData);
     _fees_init(feesData);
-    _connector_init();
+    _liquidity_mining_init(liquidityMiningData);
     description = description_;
   }
 

--- a/src/strategies/instances/aave-v3/AaveV3StrategyFactory.sol
+++ b/src/strategies/instances/aave-v3/AaveV3StrategyFactory.sol
@@ -17,6 +17,7 @@ struct AaveV3StrategyData {
   bytes creationValidationData;
   bytes guardianData;
   bytes feesData;
+  bytes liquidityMiningData;
   string description;
 }
 
@@ -28,9 +29,13 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = AaveV3Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function cloneStrategyAndRegister(
@@ -43,13 +48,14 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = AaveV3Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -65,13 +71,14 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = AaveV3Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2Strategy(
@@ -85,9 +92,13 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = AaveV3Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2StrategyAndRegister(
@@ -101,13 +112,14 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = AaveV3Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -124,13 +136,14 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = AaveV3Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function addressOfClone2(

--- a/src/strategies/instances/compound-v2/CompoundV2Strategy.sol
+++ b/src/strategies/instances/compound-v2/CompoundV2Strategy.sol
@@ -35,13 +35,20 @@ contract CompoundV2Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
     returns (StrategyId strategyId_)
   {
     strategyId_ = _baseStrategy_registerStrategy(owner);
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -50,12 +57,19 @@ contract CompoundV2Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
   {
     _strategyId = strategyId_;
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -63,15 +77,17 @@ contract CompoundV2Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     public
     initializer
   {
+    _connector_init();
     _creationValidation_init(creationValidationData);
     _guardian_init(guardianData);
     _fees_init(feesData);
-    _connector_init();
+    _liquidity_mining_init(liquidityMiningData);
     description = description_;
   }
 

--- a/src/strategies/instances/compound-v2/CompoundV2StrategyFactory.sol
+++ b/src/strategies/instances/compound-v2/CompoundV2StrategyFactory.sol
@@ -18,6 +18,7 @@ struct CompoundV2StrategyData {
   bytes creationValidationData;
   bytes guardianData;
   bytes feesData;
+  bytes liquidityMiningData;
   string description;
 }
 
@@ -29,9 +30,13 @@ contract CompoundV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = CompoundV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function cloneStrategyAndRegister(
@@ -44,13 +49,14 @@ contract CompoundV2StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = CompoundV2Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -66,13 +72,14 @@ contract CompoundV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = CompoundV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2Strategy(
@@ -86,9 +93,13 @@ contract CompoundV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = CompoundV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2StrategyAndRegister(
@@ -102,13 +113,14 @@ contract CompoundV2StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = CompoundV2Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -125,13 +137,14 @@ contract CompoundV2StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = CompoundV2Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function addressOfClone2(

--- a/src/strategies/instances/erc4626/ERC4626Strategy.sol
+++ b/src/strategies/instances/erc4626/ERC4626Strategy.sol
@@ -31,13 +31,20 @@ contract ERC4626Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
     returns (StrategyId strategyId_)
   {
     strategyId_ = _baseStrategy_registerStrategy(owner);
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -46,12 +53,19 @@ contract ERC4626Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
   {
     _strategyId = strategyId_;
-    init(creationValidationData, guardianData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      guardianData: guardianData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -59,15 +73,17 @@ contract ERC4626Strategy is
     bytes calldata creationValidationData,
     bytes calldata guardianData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     public
     initializer
   {
+    _connector_init();
     _creationValidation_init(creationValidationData);
     _guardian_init(guardianData);
     _fees_init(feesData);
-    _connector_init();
+    _liquidity_mining_init(liquidityMiningData);
     description = description_;
   }
 

--- a/src/strategies/instances/erc4626/ERC4626StrategyFactory.sol
+++ b/src/strategies/instances/erc4626/ERC4626StrategyFactory.sol
@@ -15,6 +15,7 @@ struct ERC4626StrategyData {
   bytes creationValidationData;
   bytes guardianData;
   bytes feesData;
+  bytes liquidityMiningData;
   string description;
 }
 
@@ -26,9 +27,13 @@ contract ERC4626StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = ERC4626Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function cloneStrategyAndRegister(
@@ -41,13 +46,14 @@ contract ERC4626StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = ERC4626Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -63,13 +69,14 @@ contract ERC4626StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = ERC4626Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2Strategy(
@@ -83,9 +90,13 @@ contract ERC4626StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = ERC4626Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(
-      strategyData.creationValidationData, strategyData.guardianData, strategyData.feesData, strategyData.description
-    );
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2StrategyAndRegister(
@@ -99,13 +110,14 @@ contract ERC4626StrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = ERC4626Strategy(payable(address(clone_)));
-    strategyId = clone.initAndRegister(
-      owner,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -122,13 +134,14 @@ contract ERC4626StrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = ERC4626Strategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(
-      strategyId,
-      strategyData.creationValidationData,
-      strategyData.guardianData,
-      strategyData.feesData,
-      strategyData.description
-    );
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      guardianData: strategyData.guardianData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function addressOfClone2(

--- a/src/strategies/instances/lido/LidoSTETHStrategy.sol
+++ b/src/strategies/instances/lido/LidoSTETHStrategy.sol
@@ -28,13 +28,19 @@ contract LidoSTETHStrategy is
     address owner,
     bytes calldata creationValidationData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
     returns (StrategyId strategyId_)
   {
     strategyId_ = _baseStrategy_registerStrategy(owner);
-    init(creationValidationData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
@@ -42,18 +48,25 @@ contract LidoSTETHStrategy is
     StrategyId strategyId_,
     bytes calldata creationValidationData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     external
   {
     _strategyId = strategyId_;
-    init(creationValidationData, feesData, description_);
+    init({
+      creationValidationData: creationValidationData,
+      feesData: feesData,
+      liquidityMiningData: liquidityMiningData,
+      description_: description_
+    });
   }
 
   // slither-disable-next-line reentrancy-benign
   function init(
     bytes calldata creationValidationData,
     bytes calldata feesData,
+    bytes calldata liquidityMiningData,
     string calldata description_
   )
     public
@@ -61,6 +74,7 @@ contract LidoSTETHStrategy is
   {
     _creationValidation_init(creationValidationData);
     _fees_init(feesData);
+    _liquidity_mining_init(liquidityMiningData);
     description = description_;
   }
 

--- a/src/strategies/instances/lido/LidoSTETHStrategyFactory.sol
+++ b/src/strategies/instances/lido/LidoSTETHStrategyFactory.sol
@@ -14,6 +14,7 @@ struct LidoSTETHStrategyData {
   IDelayedWithdrawalAdapter adapter;
   bytes creationValidationData;
   bytes feesData;
+  bytes liquidityMiningData;
   string description;
 }
 
@@ -25,7 +26,12 @@ contract LidoSTETHStrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = LidoSTETHStrategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(strategyData.creationValidationData, strategyData.feesData, strategyData.description);
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function cloneStrategyAndRegister(
@@ -38,8 +44,13 @@ contract LidoSTETHStrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = LidoSTETHStrategy(payable(address(clone_)));
-    strategyId =
-      clone.initAndRegister(owner, strategyData.creationValidationData, strategyData.feesData, strategyData.description);
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -55,7 +66,13 @@ contract LidoSTETHStrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone(immutableData);
     clone = LidoSTETHStrategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(strategyId, strategyData.creationValidationData, strategyData.feesData, strategyData.description);
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2Strategy(
@@ -69,7 +86,12 @@ contract LidoSTETHStrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = LidoSTETHStrategy(payable(address(clone_)));
     emit StrategyCloned(clone, StrategyIdConstants.NO_STRATEGY);
-    clone.init(strategyData.creationValidationData, strategyData.feesData, strategyData.description);
+    clone.init({
+      creationValidationData: strategyData.creationValidationData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function clone2StrategyAndRegister(
@@ -83,8 +105,13 @@ contract LidoSTETHStrategyFactory is BaseStrategyFactory {
     bytes memory immutableData = _calculateImmutableData(strategyData);
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = LidoSTETHStrategy(payable(address(clone_)));
-    strategyId =
-      clone.initAndRegister(owner, strategyData.creationValidationData, strategyData.feesData, strategyData.description);
+    strategyId = clone.initAndRegister({
+      owner: owner,
+      creationValidationData: strategyData.creationValidationData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
     // slither-disable-next-line reentrancy-events
     emit StrategyCloned(clone, strategyId);
   }
@@ -101,7 +128,13 @@ contract LidoSTETHStrategyFactory is BaseStrategyFactory {
     IEarnBalmyStrategy clone_ = _clone2(immutableData, salt);
     clone = LidoSTETHStrategy(payable(address(clone_)));
     emit StrategyCloned(clone, strategyId);
-    clone.initWithId(strategyId, strategyData.creationValidationData, strategyData.feesData, strategyData.description);
+    clone.initWithId({
+      strategyId_: strategyId,
+      creationValidationData: strategyData.creationValidationData,
+      feesData: strategyData.feesData,
+      liquidityMiningData: strategyData.liquidityMiningData,
+      description_: strategyData.description
+    });
   }
 
   function addressOfClone2(

--- a/test/unit/strategies/instances/aave-v2/AaveV2Strategy.t.sol
+++ b/test/unit/strategies/instances/aave-v2/AaveV2Strategy.t.sol
@@ -23,6 +23,7 @@ import {
   ICreationValidationManagerCore
 } from "src/interfaces/IValidationManagersRegistry.sol";
 import { IGuardianManagerCore } from "src/interfaces/IGuardianManager.sol";
+import { ILiquidityMiningManagerCore } from "src/interfaces/ILiquidityMiningManager.sol";
 import { Fees } from "src/types/Fees.sol";
 
 // solhint-disable-next-line max-states-count
@@ -37,10 +38,12 @@ contract AaveV2StrategyTest is Test {
   IFeeManagerCore private feeManager = IFeeManagerCore(address(8));
   IValidationManagersRegistryCore private validationManagerRegistry = IValidationManagersRegistryCore(address(9));
   IGuardianManagerCore private guardianManager = IGuardianManagerCore(address(10));
+  ILiquidityMiningManagerCore private liquidityMiningManager = ILiquidityMiningManagerCore(address(11));
   bytes private validationManagersStrategyData = abi.encodePacked("registryData");
   bytes private creationValidationData = abi.encode(validationManagersStrategyData, new bytes[](0));
   bytes private guardianData = abi.encodePacked("guardianData");
   bytes private feesData = abi.encodePacked("feesData");
+  bytes private liquidityMiningData = abi.encodePacked("liquidityMiningData");
   string private description = "description";
   StrategyId private strategyId = StrategyId.wrap(1);
   AaveV2StrategyFactory private factory;
@@ -72,6 +75,16 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager), abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector), ""
     );
     vm.mockCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector),
+      abi.encode("")
+    );
+    vm.mockCall(
+      address(globalRegistry),
+      abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, keccak256("LIQUIDITY_MINING_MANAGER")),
+      abi.encode(liquidityMiningManager)
+    );
+    vm.mockCall(
       address(globalRegistry),
       abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, keccak256("VALIDATION_MANAGERS_REGISTRY")),
       abi.encode(validationManagerRegistry)
@@ -97,11 +110,23 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), StrategyIdConstants.NO_STRATEGY);
     AaveV2Strategy clone = factory.cloneStrategy(
       AaveV2StrategyData(
-        vault, globalRegistry, aToken, aaveV2Pool, creationValidationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        aToken,
+        aaveV2Pool,
+        creationValidationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       )
     );
 
@@ -120,12 +145,24 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), strategyId);
     (AaveV2Strategy clone, StrategyId strategyId_) = factory.cloneStrategyAndRegister(
       owner,
       AaveV2StrategyData(
-        vault, globalRegistry, aToken, aaveV2Pool, creationValidationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        aToken,
+        aaveV2Pool,
+        creationValidationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       )
     );
 
@@ -144,12 +181,24 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), strategyId);
     AaveV2Strategy clone = factory.cloneStrategyWithId(
       strategyId,
       AaveV2StrategyData(
-        vault, globalRegistry, aToken, aaveV2Pool, creationValidationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        aToken,
+        aaveV2Pool,
+        creationValidationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       )
     );
     _assertStrategyWasDeployedCorrectly(clone, strategyId);
@@ -168,12 +217,24 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, aToken, aaveV2Pool, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), StrategyIdConstants.NO_STRATEGY);
     AaveV2Strategy clone = factory.clone2Strategy(
       AaveV2StrategyData(
-        vault, globalRegistry, aToken, aaveV2Pool, creationValidationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        aToken,
+        aaveV2Pool,
+        creationValidationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       ),
       salt
     );
@@ -194,13 +255,25 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, aToken, aaveV2Pool, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), strategyId);
     (AaveV2Strategy clone, StrategyId strategyId_) = factory.clone2StrategyAndRegister(
       owner,
       AaveV2StrategyData(
-        vault, globalRegistry, aToken, aaveV2Pool, creationValidationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        aToken,
+        aaveV2Pool,
+        creationValidationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       ),
       salt
     );
@@ -222,13 +295,25 @@ contract AaveV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, aToken, aaveV2Pool, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), strategyId);
     AaveV2Strategy clone = factory.clone2StrategyWithId(
       strategyId,
       AaveV2StrategyData(
-        vault, globalRegistry, aToken, aaveV2Pool, creationValidationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        aToken,
+        aaveV2Pool,
+        creationValidationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       ),
       salt
     );

--- a/test/unit/strategies/instances/aave-v3/AaveV3Strategy.t.sol
+++ b/test/unit/strategies/instances/aave-v3/AaveV3Strategy.t.sol
@@ -24,6 +24,7 @@ import {
   ICreationValidationManagerCore
 } from "src/interfaces/IValidationManagersRegistry.sol";
 import { IGuardianManagerCore } from "src/interfaces/IGuardianManager.sol";
+import { ILiquidityMiningManagerCore } from "src/interfaces/ILiquidityMiningManager.sol";
 import { Fees } from "src/types/Fees.sol";
 
 // solhint-disable-next-line max-states-count
@@ -39,10 +40,12 @@ contract AaveV3StrategyTest is Test {
   IFeeManagerCore private feeManager = IFeeManagerCore(address(9));
   IValidationManagersRegistryCore private validationManagerRegistry = IValidationManagersRegistryCore(address(9));
   IGuardianManagerCore private guardianManager = IGuardianManagerCore(address(10));
+  ILiquidityMiningManagerCore private liquidityMiningManager = ILiquidityMiningManagerCore(address(11));
   bytes private validationManagersStrategyData = abi.encodePacked("registryData");
   bytes private creationValidationData = abi.encode(validationManagersStrategyData, new bytes[](0));
   bytes private guardianData = abi.encodePacked("guardianData");
   bytes private feesData = abi.encodePacked("feesData");
+  bytes private liquidityMiningData = abi.encodePacked("liquidityMiningData");
   string private description = "description";
   StrategyId private strategyId = StrategyId.wrap(1);
   AaveV3StrategyFactory private factory;
@@ -74,6 +77,16 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager), abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector), ""
     );
     vm.mockCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector),
+      ""
+    );
+    vm.mockCall(
+      address(globalRegistry),
+      abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, keccak256("LIQUIDITY_MINING_MANAGER")),
+      abi.encode(liquidityMiningManager)
+    );
+    vm.mockCall(
       address(globalRegistry),
       abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, keccak256("VALIDATION_MANAGERS_REGISTRY")),
       abi.encode(validationManagerRegistry)
@@ -99,6 +112,10 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), StrategyIdConstants.NO_STRATEGY);
     AaveV3Strategy clone = factory.cloneStrategy(
@@ -111,6 +128,7 @@ contract AaveV3StrategyTest is Test {
         creationValidationData,
         guardianData,
         feesData,
+        liquidityMiningData,
         description
       )
     );
@@ -130,6 +148,10 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), strategyId);
     (AaveV3Strategy clone, StrategyId strategyId_) = factory.cloneStrategyAndRegister(
@@ -143,6 +165,7 @@ contract AaveV3StrategyTest is Test {
         creationValidationData,
         guardianData,
         feesData,
+        liquidityMiningData,
         description
       )
     );
@@ -162,6 +185,10 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), strategyId);
     AaveV3Strategy clone = factory.cloneStrategyWithId(
@@ -175,6 +202,7 @@ contract AaveV3StrategyTest is Test {
         creationValidationData,
         guardianData,
         feesData,
+        liquidityMiningData,
         description
       )
     );
@@ -194,6 +222,10 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, aToken, aaveV3Pool, aaveV3Rewards, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), StrategyIdConstants.NO_STRATEGY);
@@ -207,6 +239,7 @@ contract AaveV3StrategyTest is Test {
         creationValidationData,
         guardianData,
         feesData,
+        liquidityMiningData,
         description
       ),
       salt
@@ -228,6 +261,10 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, aToken, aaveV3Pool, aaveV3Rewards, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), strategyId);
@@ -242,6 +279,7 @@ contract AaveV3StrategyTest is Test {
         creationValidationData,
         guardianData,
         feesData,
+        liquidityMiningData,
         description
       ),
       salt
@@ -264,6 +302,10 @@ contract AaveV3StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, aToken, aaveV3Pool, aaveV3Rewards, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), strategyId);
@@ -278,6 +320,7 @@ contract AaveV3StrategyTest is Test {
         creationValidationData,
         guardianData,
         feesData,
+        liquidityMiningData,
         description
       ),
       salt

--- a/test/unit/strategies/instances/compound-v2/CompoundV2Strategy.t.sol
+++ b/test/unit/strategies/instances/compound-v2/CompoundV2Strategy.t.sol
@@ -24,6 +24,7 @@ import {
   ICreationValidationManagerCore
 } from "src/interfaces/IValidationManagersRegistry.sol";
 import { IGuardianManagerCore } from "src/interfaces/IGuardianManager.sol";
+import { ILiquidityMiningManagerCore } from "src/interfaces/ILiquidityMiningManager.sol";
 import { Fees } from "src/types/Fees.sol";
 
 // solhint-disable-next-line max-states-count
@@ -39,10 +40,12 @@ contract CompoundV2StrategyTest is Test {
   IFeeManagerCore private feeManager = IFeeManagerCore(address(9));
   IValidationManagersRegistryCore private validationManagerRegistry = IValidationManagersRegistryCore(address(9));
   IGuardianManagerCore private guardianManager = IGuardianManagerCore(address(10));
+  ILiquidityMiningManagerCore private liquidityMiningManager = ILiquidityMiningManagerCore(address(11));
   bytes private validationManagersStrategyData = abi.encodePacked("registryData");
   bytes private validationData = abi.encode(validationManagersStrategyData, new bytes[](0));
   bytes private guardianData = abi.encodePacked("guardianData");
   bytes private feesData = abi.encodePacked("feesData");
+  bytes private liquidityMiningData = abi.encodePacked("liquidityMiningData");
   string private description = "description";
   StrategyId private strategyId = StrategyId.wrap(1);
   CompoundV2StrategyFactory private factory;
@@ -74,6 +77,16 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager), abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector), ""
     );
     vm.mockCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector),
+      ""
+    );
+    vm.mockCall(
+      address(globalRegistry),
+      abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, keccak256("LIQUIDITY_MINING_MANAGER")),
+      abi.encode(liquidityMiningManager)
+    );
+    vm.mockCall(
       address(globalRegistry),
       abi.encodeWithSelector(IGlobalEarnRegistry.getAddressOrFail.selector, keccak256("VALIDATION_MANAGERS_REGISTRY")),
       abi.encode(validationManagerRegistry)
@@ -99,11 +112,25 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), StrategyIdConstants.NO_STRATEGY);
     CompoundV2Strategy clone = factory.cloneStrategy(
       CompoundV2StrategyData(
-        vault, globalRegistry, asset, cToken, comptroller, comp, validationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        asset,
+        cToken,
+        comptroller,
+        comp,
+        validationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       )
     );
 
@@ -122,12 +149,26 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), strategyId);
     (CompoundV2Strategy clone, StrategyId strategyId_) = factory.cloneStrategyAndRegister(
       owner,
       CompoundV2StrategyData(
-        vault, globalRegistry, asset, cToken, comptroller, comp, validationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        asset,
+        cToken,
+        comptroller,
+        comp,
+        validationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       )
     );
 
@@ -146,12 +187,26 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     vm.expectEmit(false, true, false, false);
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(address(0)), strategyId);
     CompoundV2Strategy clone = factory.cloneStrategyWithId(
       strategyId,
       CompoundV2StrategyData(
-        vault, globalRegistry, asset, cToken, comptroller, comp, validationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        asset,
+        cToken,
+        comptroller,
+        comp,
+        validationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       )
     );
     _assertStrategyWasDeployedCorrectly(clone, strategyId);
@@ -170,12 +225,26 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, asset, cToken, comptroller, comp, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), StrategyIdConstants.NO_STRATEGY);
     CompoundV2Strategy clone = factory.clone2Strategy(
       CompoundV2StrategyData(
-        vault, globalRegistry, asset, cToken, comptroller, comp, validationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        asset,
+        cToken,
+        comptroller,
+        comp,
+        validationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       ),
       salt
     );
@@ -196,13 +265,27 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, asset, cToken, comptroller, comp, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), strategyId);
     (CompoundV2Strategy clone, StrategyId strategyId_) = factory.clone2StrategyAndRegister(
       owner,
       CompoundV2StrategyData(
-        vault, globalRegistry, asset, cToken, comptroller, comp, validationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        asset,
+        cToken,
+        comptroller,
+        comp,
+        validationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       ),
       salt
     );
@@ -224,13 +307,27 @@ contract CompoundV2StrategyTest is Test {
       address(guardianManager),
       abi.encodeWithSelector(IGuardianManagerCore.strategySelfConfigure.selector, guardianData)
     );
+    vm.expectCall(
+      address(liquidityMiningManager),
+      abi.encodeWithSelector(ILiquidityMiningManagerCore.strategySelfConfigure.selector, liquidityMiningData)
+    );
     address cloneAddress = factory.addressOfClone2(vault, globalRegistry, asset, cToken, comptroller, comp, salt);
     vm.expectEmit();
     emit BaseStrategyFactory.StrategyCloned(IEarnBalmyStrategy(cloneAddress), strategyId);
     CompoundV2Strategy clone = factory.clone2StrategyWithId(
       strategyId,
       CompoundV2StrategyData(
-        vault, globalRegistry, asset, cToken, comptroller, comp, validationData, guardianData, feesData, description
+        vault,
+        globalRegistry,
+        asset,
+        cToken,
+        comptroller,
+        comp,
+        validationData,
+        guardianData,
+        feesData,
+        liquidityMiningData,
+        description
       ),
       salt
     );


### PR DESCRIPTION
We are now sending liquidity mining data to the manager on init. We also took the opportunity to use named params, since there are now a lot of params of the same type. To avoid confusions