### PR TITLE
fix: round beefy shares down

### DIFF
--- a/src/strategies/layers/connector/BeefyConnector.sol
+++ b/src/strategies/layers/connector/BeefyConnector.sol
@@ -267,6 +267,6 @@ abstract contract BeefyConnector is BaseConnector, Initializable {
     if (totalSupply == 0) {
       return assets;
     }
-    return assets.mulDiv(totalSupply, vault.balance(), Math.Rounding.Ceil);
+    return assets.mulDiv(totalSupply, vault.balance(), Math.Rounding.Floor);
   }
 }

--- a/test/integration/strategies/layers/connector/base/BaseConnectorImmediateWithdrawalTest.t.sol
+++ b/test/integration/strategies/layers/connector/base/BaseConnectorImmediateWithdrawalTest.t.sol
@@ -64,7 +64,7 @@ abstract contract BaseConnectorImmediateWithdrawalTest is BaseConnectorTest {
     // Check remaining balances
     (, uint256[] memory balancesAfter) = connector.totalBalances();
     for (uint256 i; i < tokens.length; ++i) {
-      assertEq(_balance(tokens[i], recipient) - recipientBalancesBefore[i], toWithdraw[i]);
+      assertAlmostEq(_balance(tokens[i], recipient) - recipientBalancesBefore[i], toWithdraw[i], 1);
       // Note: We use a delta of 1 because of rounding errors
       if (toWithdraw[i] > 0) {
         assertGte(balancesAfter[i] + 1, balancesBefore[i] - toWithdraw[i]);


### PR DESCRIPTION
We are now rounding down in `_convertAssetsToShares`, which is used in two places:
**Withdrawals:**
When calculating the amount of shares to burn during a withdrawal, we used to round up. This was an issue, because we might end up trying to burn more shares than we had, so it would revert

**Special withdrawals:**
We also used the function when calculating how many shares to transfer based on the asset amount. But again, we would be transferring more shares than the user actually owned