### PR TITLE
feat: implement self configure on fee manager

### DIFF
--- a/src/interfaces/IFeeManager.sol
+++ b/src/interfaces/IFeeManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.8;
 
+import { IEarnStrategyRegistry } from "@balmy/earn-core/interfaces/IEarnStrategyRegistry.sol";
 import { StrategyId } from "@balmy/earn-core/interfaces/IEarnStrategy.sol";
 import { Fees } from "../types/Fees.sol";
 
@@ -40,6 +41,14 @@ interface IFeeManager is IFeeManagerCore {
    * @param fees The new fees
    */
   event StrategyFeesChanged(StrategyId strategy, Fees fees);
+
+  /**
+   * @notice Returns the address of the strategy registry
+   * @return The address of the strategy registry
+   */
+  // slither-disable-start naming-convention
+
+  function STRATEGY_REGISTRY() external view returns (IEarnStrategyRegistry);
 
   /**
    * @notice Returns the role in charge of managing fees

--- a/test/unit/strategies/layers/fees/external/FeeManager.t.sol
+++ b/test/unit/strategies/layers/fees/external/FeeManager.t.sol
@@ -93,7 +93,7 @@ contract FeeManagerTest is PRBTest {
 
     vm.prank(address(strategy));
     vm.expectRevert(abi.encodeWithSelector(FeeManager.UnauthorizedCaller.selector));
-    feeManager.strategySelfConfigure(abi.encode(address(1), 10, 10));
+    feeManager.strategySelfConfigure(abi.encode(Fees(5, 1, 2, 3)));
   }
 
   function test_canWithdrawFees() public {


### PR DESCRIPTION
We are now adding a way for strategies to self-configure on the fee manager