### PR TITLE
fix: dont take funds from caller when cancelling rescue

### DIFF
--- a/src/strategies/instances/base/BaseDelayedStrategy.sol
+++ b/src/strategies/instances/base/BaseDelayedStrategy.sol
@@ -297,7 +297,7 @@ abstract contract BaseDelayedStrategy is
     override
     returns (uint256 assetsDeposited)
   {
-    return _connector_deposit(depositToken, depositAmount, true);
+    return _connector_deposit({ depositToken: depositToken, depositAmount: depositAmount, takeFromCaller: true });
   }
 
   function _fees_underlying_withdraw(

--- a/src/strategies/instances/base/BaseDelayedStrategy.sol
+++ b/src/strategies/instances/base/BaseDelayedStrategy.sol
@@ -297,7 +297,7 @@ abstract contract BaseDelayedStrategy is
     override
     returns (uint256 assetsDeposited)
   {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposit(depositToken, depositAmount, true);
   }
 
   function _fees_underlying_withdraw(

--- a/src/strategies/instances/base/BaseStrategy.sol
+++ b/src/strategies/instances/base/BaseStrategy.sol
@@ -379,13 +379,15 @@ abstract contract BaseStrategy is
 
   function _guardian_underlying_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     override
     returns (uint256 assetsDeposited)
   {
-    return _connector_deposit(depositToken, depositAmount);
+    return
+      _connector_deposit({ depositToken: depositToken, depositAmount: depositAmount, takeFromCaller: takeFromCaller });
   }
 
   function _guardian_underlying_withdraw(

--- a/src/strategies/layers/connector/AaveV2Connector.sol
+++ b/src/strategies/layers/connector/AaveV2Connector.sol
@@ -123,21 +123,23 @@ abstract contract AaveV2Connector is BaseConnector, Initializable {
   // slither-disable-next-line naming-convention,dead-code
   function _connector_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     override
     returns (uint256 assetsDeposited)
   {
+    if (takeFromCaller) {
+      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+    }
     IAToken aToken_ = aToken();
     if (depositToken == _connector_asset()) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
       uint256 balanceBefore = aToken_.balanceOf(address(this));
       pool().deposit(depositToken, depositAmount, address(this), 0);
       uint256 balanceAfter = aToken_.balanceOf(address(this));
       return balanceAfter - balanceBefore;
     } else if (depositToken == address(aToken_)) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
       return depositAmount;
     } else {
       revert InvalidDepositToken(depositToken);

--- a/src/strategies/layers/connector/AaveV3Connector.sol
+++ b/src/strategies/layers/connector/AaveV3Connector.sol
@@ -186,21 +186,23 @@ abstract contract AaveV3Connector is BaseConnector, Initializable {
   // slither-disable-next-line naming-convention,dead-code
   function _connector_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     override
     returns (uint256 assetsDeposited)
   {
+    if (takeFromCaller) {
+      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+    }
     IAToken aToken_ = aToken();
     if (depositToken == _connector_asset()) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
       uint256 balanceBefore = aToken_.balanceOf(address(this));
       pool().supply(depositToken, depositAmount, address(this), 0);
       uint256 balanceAfter = aToken_.balanceOf(address(this));
       return balanceAfter - balanceBefore;
     } else if (depositToken == address(aToken_)) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
       return depositAmount;
     } else {
       revert InvalidDepositToken(depositToken);

--- a/src/strategies/layers/connector/base/BaseConnector.sol
+++ b/src/strategies/layers/connector/base/BaseConnector.sol
@@ -34,7 +34,8 @@ abstract contract BaseConnector {
   function _connector_delayedWithdrawalAdapter(address token) internal view virtual returns (IDelayedWithdrawalAdapter);
   function _connector_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     virtual

--- a/src/strategies/layers/connector/compound-v2/CompoundV2Connector.sol
+++ b/src/strategies/layers/connector/compound-v2/CompoundV2Connector.sol
@@ -152,7 +152,8 @@ abstract contract CompoundV2Connector is BaseConnector, Initializable {
   // slither-disable-next-line naming-convention,dead-code
   function _connector_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     virtual
@@ -166,14 +167,18 @@ abstract contract CompoundV2Connector is BaseConnector, Initializable {
         // transfer native is the same as minting
         depositToken.transfer(address(cToken_), depositAmount);
       } else {
-        IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+        if (takeFromCaller) {
+          IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+        }
         uint256 errorCode = cToken_.mint(depositAmount);
         if (errorCode != 0) {
           revert InvalidMint(errorCode);
         }
       }
     } else if (depositToken == address(cToken_)) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+      if (takeFromCaller) {
+        IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+      }
     } else {
       revert InvalidDepositToken(depositToken);
     }

--- a/src/strategies/layers/connector/compound-v3/CompoundV3Connector.sol
+++ b/src/strategies/layers/connector/compound-v3/CompoundV3Connector.sol
@@ -150,22 +150,24 @@ abstract contract CompoundV3Connector is BaseConnector, Initializable {
   // slither-disable-next-line naming-convention,dead-code
   function _connector_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     virtual
     override
     returns (uint256 assetsDeposited)
   {
+    if (takeFromCaller) {
+      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+    }
     ICERC20 cToken_ = cToken();
     if (depositToken == _connector_asset()) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
       uint256 balanceBefore = cToken_.balanceOf(address(this));
       cToken_.supply(depositToken, depositAmount);
       uint256 balanceAfter = cToken_.balanceOf(address(this));
       return balanceAfter - balanceBefore;
     } else if (depositToken == address(cToken_)) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
       return depositAmount;
     } else {
       revert InvalidDepositToken(depositToken);

--- a/src/strategies/layers/connector/lido/LidoSTETHConnector.sol
+++ b/src/strategies/layers/connector/lido/LidoSTETHConnector.sol
@@ -62,7 +62,8 @@ abstract contract LidoSTETHConnector is BaseConnector, Initializable {
   // slither-disable-next-line naming-convention,dead-code
   function _connector_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     override
@@ -75,7 +76,9 @@ abstract contract LidoSTETHConnector is BaseConnector, Initializable {
       uint256 balanceAfter = IERC20(_stETH).balanceOf(address(this));
       return balanceAfter - balanceBefore;
     } else if (depositToken == address(_stETH)) {
-      IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+      if (takeFromCaller) {
+        IERC20(depositToken).safeTransferFrom(msg.sender, address(this), depositAmount);
+      }
       return depositAmount;
     } else {
       revert InvalidDepositToken(depositToken);

--- a/src/strategies/layers/guardian/base/BaseGuardian.sol
+++ b/src/strategies/layers/guardian/base/BaseGuardian.sol
@@ -24,7 +24,8 @@ abstract contract BaseGuardian {
     returns (address[] memory tokens, uint256[] memory balances);
   function _guardian_underlying_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     virtual

--- a/src/strategies/layers/guardian/external/ExternalGuardian.sol
+++ b/src/strategies/layers/guardian/external/ExternalGuardian.sol
@@ -110,7 +110,8 @@ abstract contract ExternalGuardian is BaseGuardian, Initializable {
 
     address[] memory tokens = _guardian_underlying_tokens();
     uint256 assetBalance = tokens[0].balanceOf(address(this));
-    _guardian_underlying_deposit(tokens[0], assetBalance);
+    // Since funds are already on the contract, there is no need to take them from the caller
+    _guardian_underlying_deposit({ depositToken: tokens[0], depositAmount: assetBalance, takeFromCaller: false });
 
     rescueConfig = RescueConfig({ feeBps: 0, feeRecipient: address(0), status: RescueStatus.OK });
 
@@ -190,7 +191,8 @@ abstract contract ExternalGuardian is BaseGuardian, Initializable {
     if (rescueConfig.status != RescueStatus.OK) {
       revert InvalidRescueStatus();
     }
-    return _guardian_underlying_deposit(depositToken, depositAmount);
+    return
+      _guardian_underlying_deposit({ depositToken: depositToken, depositAmount: depositAmount, takeFromCaller: true });
   }
 
   // slither-disable-start naming-convention,dead-code

--- a/test/integration/strategies/layers/connector/base/BaseConnectorInstance.sol
+++ b/test/integration/strategies/layers/connector/base/BaseConnectorInstance.sol
@@ -47,7 +47,7 @@ abstract contract BaseConnectorInstance is BaseConnector {
   }
 
   function deposit(address depositToken, uint256 depositAmount) external payable returns (uint256 assetsDeposited) {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposit({ depositToken: depositToken, depositAmount: depositAmount, takeFromCaller: true });
   }
 
   function withdraw(

--- a/test/integration/strategies/layers/connector/base/BaseConnectorTest.t.sol
+++ b/test/integration/strategies/layers/connector/base/BaseConnectorTest.t.sol
@@ -118,7 +118,7 @@ abstract contract BaseConnectorTest is PRBTest, StdUtils, StdCheats {
 
   function testFork_deposit_RevertWhen_InvalidToken() public {
     address token = address(1);
-    vm.expectRevert(abi.encodeWithSelector(BaseConnector.InvalidDepositToken.selector, token));
+    vm.expectRevert();
     connector.deposit(token, 1e18);
   }
 

--- a/test/mocks/strategies/LidoSTETHStrategyMock.sol
+++ b/test/mocks/strategies/LidoSTETHStrategyMock.sol
@@ -95,7 +95,7 @@ contract LidoSTETHStrategyMock is IEarnBalmyStrategy, LidoSTETHConnector {
 
   /// @inheritdoc IEarnStrategy
   function deposit(address depositToken, uint256 depositAmount) external payable returns (uint256 assetsDeposited) {
-    return _connector_deposit(depositToken, depositAmount);
+    return _connector_deposit({ depositToken: depositToken, depositAmount: depositAmount, takeFromCaller: true });
   }
 
   /// @inheritdoc IEarnStrategy

--- a/test/unit/strategies/layers/guardian/external/ExternalGuardian.t.sol
+++ b/test/unit/strategies/layers/guardian/external/ExternalGuardian.t.sol
@@ -145,6 +145,7 @@ contract ExternalGuardianTest is Test {
     ExternalGuardianInstance.Deposit memory deposit = guardian.lastDeposit();
     assertEq(deposit.token, asset);
     assertEq(deposit.amount, balance);
+    assertEq(deposit.takeFromCaller, false);
     (uint16 feeBps, address feeRecipient, ExternalGuardian.RescueStatus status) = guardian.rescueConfig();
     assertEq(feeBps, 0);
     assertEq(feeRecipient, address(0));
@@ -288,6 +289,7 @@ contract ExternalGuardianTest is Test {
     ExternalGuardianInstance.Deposit memory deposit = guardian.lastDeposit();
     assertEq(deposit.token, asset);
     assertEq(deposit.amount, amount);
+    assertEq(deposit.takeFromCaller, true);
     assertEq(deposited, amount);
   }
 
@@ -417,6 +419,7 @@ contract ExternalGuardianInstance is ExternalGuardian {
   struct Deposit {
     address token;
     uint256 amount;
+    bool takeFromCaller;
   }
 
   struct SpecialWithdrawal {
@@ -558,13 +561,14 @@ contract ExternalGuardianInstance is ExternalGuardian {
 
   function _guardian_underlying_deposit(
     address depositToken,
-    uint256 depositAmount
+    uint256 depositAmount,
+    bool takeFromCaller
   )
     internal
     override
     returns (uint256 assetsDeposited)
   {
-    _deposit = Deposit(depositToken, depositAmount);
+    _deposit = Deposit(depositToken, depositAmount, takeFromCaller);
     return depositAmount;
   }
 


### PR DESCRIPTION
Since #135, the strategy (or connectors) would need to take funds from the caller on a deposit. The thing is that when a rescue is cancelled, we would need to re-deposit the asset, but with the funds already on the contract

So we are now adding a new param to the connector to specify whether it should take funds from the user or not