### PR TITLE
fix: initialize fees on register

### DIFF
--- a/src/strategies/instances/base/BaseDelayedStrategy.sol
+++ b/src/strategies/instances/base/BaseDelayedStrategy.sol
@@ -178,7 +178,7 @@ abstract contract BaseDelayedStrategy is
     onlyStrategyRegistry
   {
     _strategyId = strategyId_;
-    _connector_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
+    _fees_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
   }
 
   modifier onlyStrategyRegistry() {
@@ -340,6 +340,17 @@ abstract contract BaseDelayedStrategy is
     returns (IEarnStrategy.WithdrawalType[] memory)
   {
     return _connector_supportedWithdrawals();
+  }
+
+  function _fees_underlying_strategyRegistered(
+    StrategyId strategyId_,
+    IEarnStrategy oldStrategy,
+    bytes calldata migrationResultData
+  )
+    internal
+    override
+  {
+    _connector_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
   }
 
   ////////////////////////////////////////////////////////

--- a/src/strategies/instances/base/BaseStrategy.sol
+++ b/src/strategies/instances/base/BaseStrategy.sol
@@ -181,7 +181,7 @@ abstract contract BaseStrategy is
     onlyStrategyRegistry
   {
     _strategyId = strategyId_;
-    _connector_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
+    _fees_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
   }
 
   modifier onlyStrategyRegistry() {
@@ -341,6 +341,17 @@ abstract contract BaseStrategy is
     )
   {
     return _guardian_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
+  }
+
+  function _fees_underlying_strategyRegistered(
+    StrategyId strategyId_,
+    IEarnStrategy oldStrategy,
+    bytes calldata migrationResultData
+  )
+    internal
+    override
+  {
+    _connector_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
   }
 
   ////////////////////////////////////////////////////////

--- a/src/strategies/layers/fees/base/BaseFees.sol
+++ b/src/strategies/layers/fees/base/BaseFees.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.22;
 
-import { IEarnStrategy, SpecialWithdrawalCode } from "@balmy/earn-core/interfaces/IEarnStrategy.sol";
+import { IEarnStrategy, SpecialWithdrawalCode, StrategyId } from "@balmy/earn-core/interfaces/IEarnStrategy.sol";
 
 abstract contract BaseFees {
   // slither-disable-start naming-convention
@@ -50,6 +50,14 @@ abstract contract BaseFees {
     virtual
     returns (IEarnStrategy.WithdrawalType[] memory);
 
+  function _fees_underlying_strategyRegistered(
+    StrategyId strategyId_,
+    IEarnStrategy oldStrategy,
+    bytes calldata migrationResultData
+  )
+    internal
+    virtual;
+
   // Fees
   function _fees_fees() internal view virtual returns (IEarnStrategy.FeeType[] memory types, uint16[] memory bps);
   function _fees_totalBalances() internal view virtual returns (address[] memory tokens, uint256[] memory balances);
@@ -86,5 +94,12 @@ abstract contract BaseFees {
       uint256[] memory actualWithdrawnAmounts,
       bytes memory result
     );
+  function _fees_strategyRegistered(
+    StrategyId strategyId_,
+    IEarnStrategy oldStrategy,
+    bytes calldata migrationResultData
+  )
+    internal
+    virtual;
   // slither-disable-end naming-convention
 }

--- a/src/strategies/layers/fees/external/ExternalFees.sol
+++ b/src/strategies/layers/fees/external/ExternalFees.sol
@@ -244,7 +244,7 @@ abstract contract ExternalFees is BaseFees, ReentrancyGuard, Initializable {
     }
   }
 
-  // slither-disable-next-line dead-code
+  // slither-disable-next-line naming-convention,dead-code
   function _fees_strategyRegistered(
     StrategyId strategyId_,
     IEarnStrategy oldStrategy,

--- a/src/strategies/layers/fees/external/ExternalFees.sol
+++ b/src/strategies/layers/fees/external/ExternalFees.sol
@@ -244,6 +244,7 @@ abstract contract ExternalFees is BaseFees, ReentrancyGuard, Initializable {
     }
   }
 
+  // slither-disable-next-line dead-code
   function _fees_strategyRegistered(
     StrategyId strategyId_,
     IEarnStrategy oldStrategy,

--- a/test/unit/strategies/layers/fees/external/ExternalFees.t.sol
+++ b/test/unit/strategies/layers/fees/external/ExternalFees.t.sol
@@ -243,7 +243,8 @@ contract ExternalFeesTest is Test {
 
   function test_totalBalances() public {
     _setFee(500); // 5%
-    fees.init(""); // Initialize so that performance data is set
+    fees.strategyRegistered(StrategyId.wrap(1), IEarnStrategy(address(0)), ""); // Register so that performance data is
+      // set
 
     // Deposit 50k
     fees.deposit(asset, 50_000);
@@ -267,7 +268,8 @@ contract ExternalFeesTest is Test {
     uint256 positionId = 1;
     address recipient = address(0);
     address[] memory allTokens = CommonUtils.arrayOf(asset, token);
-    fees.init(""); // Initialize so that performance data is set
+    fees.strategyRegistered(StrategyId.wrap(1), IEarnStrategy(address(0)), ""); // Register so that performance data is
+      // set
 
     // Deposit 50k
     fees.deposit(asset, 50_000);
@@ -531,6 +533,16 @@ contract ExternalFeesInstance is ExternalFees {
     return _fees_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
   }
 
+  function strategyRegistered(
+    StrategyId strategyId_,
+    IEarnStrategy oldStrategy,
+    bytes calldata migrationResultData
+  )
+    external
+  {
+    return _fees_strategyRegistered(strategyId_, oldStrategy, migrationResultData);
+  }
+
   function globalRegistry() public view override returns (IGlobalEarnRegistry) {
     return _registry;
   }
@@ -638,4 +650,13 @@ contract ExternalFeesInstance is ExternalFees {
       types[i] = _types[_tokens[i]];
     }
   }
+
+  function _fees_underlying_strategyRegistered(
+    StrategyId strategyId_,
+    IEarnStrategy oldStrategy,
+    bytes calldata migrationResultData
+  )
+    internal
+    override
+  { }
 }


### PR DESCRIPTION
Before this change, we would initialize all fee config during `init`. The problem is that it wouldn't work correctly during a migration, so we have moved that part to `strategyRegistered` instead