### PR TITLE
fix: move distributor

### DIFF
--- a/script/DeployManagers.sol
+++ b/script/DeployManagers.sol
@@ -120,7 +120,7 @@ contract DeployManagers is BaseDeployPeriphery {
     initialMorphoRewardsAdmins[1] = relayer;
 
     address morphoRewardsManager = deployContract(
-      "V1_RM_MORPHO",
+      "V2_RM_MORPHO",
       abi.encodePacked(type(MorphoRewardsManager).creationCode, abi.encode(admin, initialMorphoRewardsAdmins))
     );
     console2.log("Rewards manager deployed: ", morphoRewardsManager);

--- a/src/strategies/layers/connector/morpho/MorphoRewardsManager.sol
+++ b/src/strategies/layers/connector/morpho/MorphoRewardsManager.sol
@@ -13,12 +13,12 @@ import { MorphoConnector } from "./MorphoConnector.sol";
  */
 contract MorphoRewardsManager is AccessControlDefaultAdminRules {
   struct Claims {
-    IUniversalRewardsDistributor rewardsDistributor;
     MorphoConnector connector;
     Claim[] claims;
   }
 
   struct Claim {
+    IUniversalRewardsDistributor rewardsDistributor;
     address rewardToken;
     uint256 claimable;
     bytes32[] proof;
@@ -79,7 +79,7 @@ contract MorphoRewardsManager is AccessControlDefaultAdminRules {
     for (uint256 i = 0; i < claims.claims.length; ++i) {
       Claim memory claim_ = claims.claims[i];
       // slither-disable-next-line unused-return,calls-loop
-      claims.rewardsDistributor.claim(address(claims.connector), claim_.rewardToken, claim_.claimable, claim_.proof);
+      claim_.rewardsDistributor.claim(address(claims.connector), claim_.rewardToken, claim_.claimable, claim_.proof);
       tokens[i] = claim_.rewardToken;
     }
   }

--- a/test/unit/strategies/layers/connector/morpho/MorphoRewardsManager.t.sol
+++ b/test/unit/strategies/layers/connector/morpho/MorphoRewardsManager.t.sol
@@ -44,10 +44,14 @@ contract MorphoRewardsManagerTest is Test {
     bytes32[] memory proof = new bytes32[](0);
 
     MorphoRewardsManager.Claim[] memory claims = new MorphoRewardsManager.Claim[](1);
-    claims[0] = MorphoRewardsManager.Claim({ rewardToken: rewardToken, claimable: claimable, proof: proof });
+    claims[0] = MorphoRewardsManager.Claim({
+      rewardsDistributor: rewardsDistributor,
+      rewardToken: rewardToken,
+      claimable: claimable,
+      proof: proof
+    });
     MorphoRewardsManager.Claims[] memory allClaims = new MorphoRewardsManager.Claims[](1);
-    allClaims[0] =
-      MorphoRewardsManager.Claims({ connector: connector, rewardsDistributor: rewardsDistributor, claims: claims });
+    allClaims[0] = MorphoRewardsManager.Claims({ connector: connector, claims: claims });
 
     vm.expectCall(
       address(rewardsDistributor),
@@ -96,10 +100,14 @@ contract MorphoRewardsManagerTest is Test {
     bytes32[] memory proof = new bytes32[](0);
 
     MorphoRewardsManager.Claim[] memory claims = new MorphoRewardsManager.Claim[](1);
-    claims[0] = MorphoRewardsManager.Claim({ rewardToken: rewardToken, claimable: claimable, proof: proof });
+    claims[0] = MorphoRewardsManager.Claim({
+      rewardsDistributor: rewardsDistributor,
+      rewardToken: rewardToken,
+      claimable: claimable,
+      proof: proof
+    });
     MorphoRewardsManager.Claims[] memory allClaims = new MorphoRewardsManager.Claims[](1);
-    allClaims[0] =
-      MorphoRewardsManager.Claims({ connector: connector, rewardsDistributor: rewardsDistributor, claims: claims });
+    allClaims[0] = MorphoRewardsManager.Claims({ connector: connector, claims: claims });
 
     vm.expectCall(
       address(rewardsDistributor),


### PR DESCRIPTION
It seems that the same strategy can have rewards in different distributors, so we need to move it to individual claims