### PR TITLE
fix: dont redeposit on cancel

### DIFF
--- a/src/strategies/layers/guardian/external/ExternalGuardian.sol
+++ b/src/strategies/layers/guardian/external/ExternalGuardian.sol
@@ -108,8 +108,11 @@ abstract contract ExternalGuardian is BaseGuardian, Initializable {
 
     address[] memory tokens = _guardian_underlying_tokens();
     uint256 assetBalance = tokens[0].balanceOf(address(this));
-    // Since funds are already on the contract, there is no need to take them from the caller
-    _guardian_underlying_deposit({ depositToken: tokens[0], depositAmount: assetBalance, takeFromCaller: false });
+
+    if (assetBalance > 0) {
+      // Since funds are already on the contract, there is no need to take them from the caller
+      _guardian_underlying_deposit({ depositToken: tokens[0], depositAmount: assetBalance, takeFromCaller: false });
+    }
 
     rescueConfig = RescueConfig({ feeBps: 0, feeRecipient: address(0), status: RescueStatus.OK });
 


### PR DESCRIPTION
We will avoid re-depositing when a rescue is cancelled if the balance is 0