### PR TITLE
fix: special withdraw in morpho connector

### DIFF
--- a/src/strategies/layers/connector/ERC4626Connector.sol
+++ b/src/strategies/layers/connector/ERC4626Connector.sol
@@ -175,6 +175,7 @@ abstract contract ERC4626Connector is BaseConnector, Initializable {
     address recipient
   )
     internal
+    virtual
     override
     returns (
       uint256[] memory balanceChanges,

--- a/src/strategies/layers/connector/morpho/MorphoConnector.sol
+++ b/src/strategies/layers/connector/morpho/MorphoConnector.sol
@@ -166,7 +166,8 @@ abstract contract MorphoConnector is ERC4626Connector {
     )
   {
     uint256[] memory superBalanceChanges;
-    (superBalanceChanges, actualWithdrawnTokens, actualWithdrawnAmounts, result) = super._connector_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
+    (superBalanceChanges, actualWithdrawnTokens, actualWithdrawnAmounts, result) =
+      super._connector_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
     balanceChanges = new uint256[](_rewardTokens.length + 1);
     balanceChanges[0] = superBalanceChanges[0];
   }

--- a/src/strategies/layers/connector/morpho/MorphoConnector.sol
+++ b/src/strategies/layers/connector/morpho/MorphoConnector.sol
@@ -5,7 +5,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { Token } from "@balmy/earn-core/libraries/Token.sol";
 import { IGlobalEarnRegistry } from "src/interfaces/IGlobalEarnRegistry.sol";
-import { ERC4626Connector, IEarnStrategy, StrategyId } from "../ERC4626Connector.sol";
+import { ERC4626Connector, IEarnStrategy, StrategyId, SpecialWithdrawalCode } from "../ERC4626Connector.sol";
 
 /**
  * @notice Some farms like Aave v3 generate rewards continuously over time. But other farms (like Morpho) do the
@@ -146,6 +146,29 @@ abstract contract MorphoConnector is ERC4626Connector {
     // Note: we should technically re-size the array params but we know the ERC4626 connector doesn't need it, so we
     //       won't. This will help us reduce contract size
     super._connector_withdraw(positionId, tokens, toWithdraw, recipient);
+  }
+
+  // slither-disable-next-line naming-convention,dead-code
+  function _connector_specialWithdraw(
+    uint256 positionId,
+    SpecialWithdrawalCode withdrawalCode,
+    uint256[] calldata toWithdraw,
+    bytes calldata withdrawData,
+    address recipient
+  )
+    internal
+    override
+    returns (
+      uint256[] memory balanceChanges,
+      address[] memory actualWithdrawnTokens,
+      uint256[] memory actualWithdrawnAmounts,
+      bytes memory result
+    )
+  {
+    uint256[] memory superBalanceChanges;
+    (superBalanceChanges, actualWithdrawnTokens, actualWithdrawnAmounts, result) = super._connector_specialWithdraw(positionId, withdrawalCode, toWithdraw, withdrawData, recipient);
+    balanceChanges = new uint256[](_rewardTokens.length + 1);
+    balanceChanges[0] = superBalanceChanges[0];
   }
 
   // slither-disable-next-line naming-convention,dead-code

--- a/test/integration/strategies/layers/connector/morpho/MorphoConnectorTest.t.sol
+++ b/test/integration/strategies/layers/connector/morpho/MorphoConnectorTest.t.sol
@@ -211,7 +211,7 @@ contract MorphoConnectorTest is BaseConnectorImmediateWithdrawalTest, BaseConnec
 
   function testFork_specialWithdraw_withRewards() public {
     _sendAndConfigureRewards(_MORPHO_TOKEN, 8640e10, 1 days);
-     address recipient = address(1);
+    address recipient = address(1);
     uint256 originalConnectorBalance = _connectorBalanceOfFarmToken();
     uint256 amountToWithdraw = _amountToWithdrawFarmToken();
     uint256[] memory toWithdraw = new uint256[](1);


### PR DESCRIPTION
Before this change, we weren't resizing `balanceChanges` during special withdrawals. This meant that the vault would revert if special withdraw was called